### PR TITLE
refactor: use relative paths for vendored Flare imports

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,15 +10,6 @@ evm_version = "cancun"
 bytecode_hash = "none"
 cbor_metadata = false
 
-# Vendored Flare interface files (MIT-licensed, under src/vendor/).
-# Neither flare-smart-contracts repo is on soldeer; only these specific
-# interfaces are needed, so they're checked in rather than pulled as
-# submodules.
-remappings = [
-  "flare-smart-contracts/=src/vendor/flare-smart-contracts/",
-  "flare-smart-contracts-v2/=src/vendor/flare-smart-contracts-v2/",
-]
-
 fs_permissions = [
   { access = "read-write", path = "src/generated" },
   { access = "read-write", path = "meta" },

--- a/src/err/ErrFtso.sol
+++ b/src/err/ErrFtso.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.19;
 
-import {IFtso} from "flare-smart-contracts/userInterfaces/IFtso.sol";
+import {IFtso} from "../vendor/flare-smart-contracts/userInterfaces/IFtso.sol";
 
 /// Workaround for https://github.com/foundry-rs/foundry/issues/6572
 contract ErrFtso {}

--- a/src/interface/IGoverned.sol
+++ b/src/interface/IGoverned.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.25;
 
-import {IGovernanceSettings} from "flare-smart-contracts/userInterfaces/IGovernanceSettings.sol";
+import {IGovernanceSettings} from "../vendor/flare-smart-contracts/userInterfaces/IGovernanceSettings.sol";
 
 interface IGoverned {
     function governance() external view returns (address);

--- a/src/lib/lts/LibFtsoV2LTS.sol
+++ b/src/lib/lts/LibFtsoV2LTS.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.19;
 
 //forge-lint: disable-next-line(unused-import)
 import {IFtsoRegistry, LibFlareContractRegistry} from "../registry/LibFlareContractRegistry.sol";
-import {FtsoV2Interface} from "flare-smart-contracts-v2/userInterfaces/LTS/FtsoV2Interface.sol";
+import {FtsoV2Interface} from "../../vendor/flare-smart-contracts-v2/userInterfaces/LTS/FtsoV2Interface.sol";
 import {StalePrice} from "../../err/ErrFtso.sol";
-import {IFeeCalculator} from "flare-smart-contracts-v2/userInterfaces/IFeeCalculator.sol";
+import {IFeeCalculator} from "../../vendor/flare-smart-contracts-v2/userInterfaces/IFeeCalculator.sol";
 
 /// @dev FTSO feed IDs.
 /// https://dev.flare.network/ftso/feeds

--- a/src/lib/price/LibFtsoCurrentPriceUsd.sol
+++ b/src/lib/price/LibFtsoCurrentPriceUsd.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 
 import {IFtsoRegistry, LibFlareContractRegistry} from "../registry/LibFlareContractRegistry.sol";
 import {InactiveFtso, PriceNotFinalized, StalePrice, InconsistentFtso} from "../../err/ErrFtso.sol";
-import {IFtso} from "flare-smart-contracts/userInterfaces/IFtso.sol";
+import {IFtso} from "../../vendor/flare-smart-contracts/userInterfaces/IFtso.sol";
 
 library LibFtsoCurrentPriceUsd {
     function ftsoCurrentPriceUsd(string memory symbol, uint256 timeout) internal view returns (uint256, uint256) {

--- a/src/lib/registry/LibFlareContractRegistry.sol
+++ b/src/lib/registry/LibFlareContractRegistry.sol
@@ -2,12 +2,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.19;
 
-import {FtsoV2Interface} from "flare-smart-contracts-v2/userInterfaces/LTS/FtsoV2Interface.sol";
-import {IFeeCalculator} from "flare-smart-contracts-v2/userInterfaces/IFeeCalculator.sol";
-import {IFtsoRegistry} from "flare-smart-contracts/userInterfaces/IFtsoRegistry.sol";
-import {IFlareContractRegistry} from "flare-smart-contracts/userInterfaces/IFlareContractRegistry.sol";
+import {FtsoV2Interface} from "../../vendor/flare-smart-contracts-v2/userInterfaces/LTS/FtsoV2Interface.sol";
+import {IFeeCalculator} from "../../vendor/flare-smart-contracts-v2/userInterfaces/IFeeCalculator.sol";
+import {IFtsoRegistry} from "../../vendor/flare-smart-contracts/userInterfaces/IFtsoRegistry.sol";
+import {IFlareContractRegistry} from "../../vendor/flare-smart-contracts/userInterfaces/IFlareContractRegistry.sol";
 //forge-lint: disable-next-line(unused-import)
-import {IFtso} from "flare-smart-contracts/userInterfaces/IFtso.sol";
+import {IFtso} from "../../vendor/flare-smart-contracts/userInterfaces/IFtso.sol";
 
 // The address of the Flare contract registry.
 // This is the same and immutable across all Flare networks

--- a/test/prod/FlareInterfacesProd.t.sol
+++ b/test/prod/FlareInterfacesProd.t.sol
@@ -6,11 +6,11 @@ import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "../fork/LibFork.sol";
 import {BLOCK_NUMBER} from "../src/lib/registry/LibFlareContractRegistry.t.sol";
 
-import {IFlareContractRegistry} from "flare-smart-contracts/userInterfaces/IFlareContractRegistry.sol";
-import {IFtsoRegistry} from "flare-smart-contracts/userInterfaces/IFtsoRegistry.sol";
-import {IFtso} from "flare-smart-contracts/userInterfaces/IFtso.sol";
-import {FtsoV2Interface} from "flare-smart-contracts-v2/userInterfaces/LTS/FtsoV2Interface.sol";
-import {IFeeCalculator} from "flare-smart-contracts-v2/userInterfaces/IFeeCalculator.sol";
+import {IFlareContractRegistry} from "../../src/vendor/flare-smart-contracts/userInterfaces/IFlareContractRegistry.sol";
+import {IFtsoRegistry} from "../../src/vendor/flare-smart-contracts/userInterfaces/IFtsoRegistry.sol";
+import {IFtso} from "../../src/vendor/flare-smart-contracts/userInterfaces/IFtso.sol";
+import {FtsoV2Interface} from "../../src/vendor/flare-smart-contracts-v2/userInterfaces/LTS/FtsoV2Interface.sol";
+import {IFeeCalculator} from "../../src/vendor/flare-smart-contracts-v2/userInterfaces/IFeeCalculator.sol";
 
 import {
     FLARE_CONTRACT_REGISTRY,

--- a/test/src/lib/lts/LibFtsoV2LTS.t.sol
+++ b/test/src/lib/lts/LibFtsoV2LTS.t.sol
@@ -7,7 +7,7 @@ import {LibFtsoV2LTS, ETH_USD_FEED_ID} from "src/lib/lts/LibFtsoV2LTS.sol";
 import {BLOCK_NUMBER} from "../registry/LibFlareContractRegistry.t.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {LibFlareContractRegistry} from "src/lib/registry/LibFlareContractRegistry.sol";
-import {IFeeCalculator} from "flare-smart-contracts-v2/userInterfaces/IFeeCalculator.sol";
+import {IFeeCalculator} from "../../../../src/vendor/flare-smart-contracts-v2/userInterfaces/IFeeCalculator.sol";
 import {IGoverned, IGovernanceSettings} from "src/interface/IGoverned.sol";
 import {IGovernedFeeCalculator} from "src/interface/IGovernedFeeCalculator.sol";
 import {StalePrice} from "src/err/ErrFtso.sol";


### PR DESCRIPTION
## Summary
- Drop the `flare-smart-contracts/=src/vendor/...` and `flare-smart-contracts-v2/=...` remappings from `foundry.toml`.
- Rewrite source imports that used them to relative paths into `src/vendor/`.
- Downstream soldeer consumers (e.g. rain.vats) no longer need a bridge remapping to pull these interfaces transitively — the relative paths resolve correctly whether rain.flare is at `./src/...` or `dependencies/rain-flare-X.Y.Z/src/...`.

Closes #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized dependency import structure across library contracts, interfaces, and test files to use consistent local vendor paths instead of package-style import mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.flare/pull/35)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->