### PR TITLE
chore: bump rainlang dep 0.1.1 -> 0.1.2

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -32,7 +32,7 @@ forge-std = "1.16.1"
 "rain-solmem" = "0.1.3"
 "rain-string" = "0.2.0"
 "rain-tofu-erc20-decimals" = "0.1.1"
-"rainlang" = "0.1.1"
+"rainlang" = "0.1.2"
 
 [soldeer]
 recursive_deps = false

--- a/remappings.txt
+++ b/remappings.txt
@@ -15,3 +15,4 @@ rain-solmem-0.1.3/=dependencies/rain-solmem-0.1.3/
 rain-string-0.2.0/=dependencies/rain-string-0.2.0/
 rain-tofu-erc20-decimals-0.1.1/=dependencies/rain-tofu-erc20-decimals-0.1.1/
 rainlang-0.1.1/=dependencies/rainlang-0.1.1/
+rainlang-0.1.2/=dependencies/rainlang-0.1.2/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -13,6 +13,20 @@ checksum = "839b61832925c7152c7b6dffbfa4998d9e606211179bd8f604733124e8a7cb57"
 integrity = "60e55d10150354ca4a1e2985c5456c834b92b82ef85ab0e1d92a7786cddbd219"
 
 [[dependencies]]
+name = "rain-deploy"
+version = "0.1.2"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-deploy/0_1_2_09-05-2026_19:49:20_rain.zip"
+checksum = "94d3daf2f9f90062d2e676077c2b4ccd2bdd66201665a2209e98016e155f619a"
+integrity = "10bff708d9e5d8b77655b8a8fc0c755cef8e3fc876cc3ff100425d27b08294a0"
+
+[[dependencies]]
+name = "rain-extrospection"
+version = "0.1.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-extrospection/0_1_0_11-05-2026_12:26:12_rain.zip"
+checksum = "97297c3f1d623c63f5996b4266a4c26f895a1ca17ab271a619af601f8950521d"
+integrity = "30f7e23c71b24267d2db46085049aec5baaa693825ff8bc8fd72bd685da479ad"
+
+[[dependencies]]
 name = "rain-interpreter-interface"
 version = "0.1.0"
 url = "https://soldeer-revisions.s3.amazonaws.com/rain-interpreter-interface/0_1_0_12-05-2026_18:43:02_rain.interpreter.zip"
@@ -27,11 +41,32 @@ checksum = "6cd4b0e5ea0a7ffc8adef762b3687d180e4c1408ec4ff8bf8d88d5f9712bf5af"
 integrity = "cad9d7a463dd388f73b1f2cf85dd212fd46320203f8d39cb0938ffb451295384"
 
 [[dependencies]]
+name = "rain-lib-hash"
+version = "0.1.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-lib-hash/0_1_0_12-05-2026_16:24:56_rain.lib.zip"
+checksum = "648f3e38b297dbd3ecb32b82c8b24c322f484e1734eb50fd393bc547c72b59b0"
+integrity = "91f5f679a0a27f096fdbc1e41195dd9f42cacfab15735efeb1101cc1b9215b47"
+
+[[dependencies]]
+name = "rain-lib-memkv"
+version = "0.1.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-lib-memkv/0_1_0_12-05-2026_19:04:20_rain.lib.zip"
+checksum = "69142c50851359c0b19ba0e59c387623a90debd16fb1c3a907aa2809a6873b1f"
+integrity = "f2a63c0466c50cbfb3b3545094890c74dd1116b55fcb738bb631471252cee5b8"
+
+[[dependencies]]
 name = "rain-lib-typecast"
 version = "0.1.0"
 url = "https://soldeer-revisions.s3.amazonaws.com/rain-lib-typecast/0_1_0_12-05-2026_16:31:39_rain.lib.zip"
 checksum = "5c0419501e4c763ef161a3489934af192219f994cb2c9187699bc4dee0b4e2bb"
 integrity = "092781f87fd9227c4c95aafde59300c503d6a9a355beaeb5c5732fe6e36676d6"
+
+[[dependencies]]
+name = "rain-math-binary"
+version = "0.1.1"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-math-binary/0_1_1_09-05-2026_19:49:57_rain.math.zip"
+checksum = "6f966e4f5f59103b62de2004005db508824622495b893a646d0e2a35511f0093"
+integrity = "4cfaa11c0e48ac46824a10fec2184863d114f09c171544b721d782386708dca7"
 
 [[dependencies]]
 name = "rain-math-float"
@@ -55,8 +90,29 @@ checksum = "6b5abd394c5db86ac64214262b7a5115158f480b2fbd74442672dfe52bb67310"
 integrity = "e22748ce2ba7eca3ce71e23b2271d1c0f370b989507e784b0a4850a7a9e52157"
 
 [[dependencies]]
-name = "rainlang"
+name = "rain-solmem"
+version = "0.1.3"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-solmem/0_1_3_09-05-2026_19:49:33_rain.zip"
+checksum = "1d405bb81f7c9e56d1717de0d60da918d2fc2fa4db083efd2abe9906378d019f"
+integrity = "e879d2743f9d884f647b9dd489889a83f2cea5f76eb69409a113e1baa69d3643"
+
+[[dependencies]]
+name = "rain-string"
+version = "0.2.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-string/0_2_0_09-05-2026_21:16:31_rain.zip"
+checksum = "847b9366128c5dcc5849c6938ae7ac92561ed8185bf304f1b1eb9ef59d77954e"
+integrity = "7cb6ee638b59b840ea59e014e2610fdccc30a1593e763590e298314f00700561"
+
+[[dependencies]]
+name = "rain-tofu-erc20-decimals"
 version = "0.1.1"
-url = "https://soldeer-revisions.s3.amazonaws.com/rainlang/0_1_1_14-05-2026_07:01:44_rainlang.zip"
-checksum = "8297278d5b98c1fc2778d756e63bf964d336eaa304d3812a916de83ed308ce15"
-integrity = "82213331ad557c000157641f22bebfe5d99622c3884434593a1d51239b46e377"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-tofu-erc20-decimals/0_1_1_12-05-2026_15:44:19_rain.tofu.zip"
+checksum = "2a48a362ac80a85a8792492fcaf943a86a95009a8aeaced3b50554bbed1e5874"
+integrity = "9e1fccf893dd0d90aeb445c78f9eee3904bc50287ff1da30b954508f18412cd2"
+
+[[dependencies]]
+name = "rainlang"
+version = "0.1.2"
+url = "https://soldeer-revisions.s3.amazonaws.com/rainlang/0_1_2_14-05-2026_19:37:46_rainlang.zip"
+checksum = "87f4056d17bc103d6ca8d1881fe64c67d74d36f67ec1d858d071e3f77a449845"
+integrity = "8c93188eddb2df33bc3c0e4f529f5de8476e813803bbaadc59500f6d37baebce"

--- a/src/abstract/FlareFtsoExtern.sol
+++ b/src/abstract/FlareFtsoExtern.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.25;
 
-import {BaseRainlangExtern, OperandV2, StackItem} from "rainlang-0.1.1/src/abstract/BaseRainlangExtern.sol";
+import {BaseRainlangExtern, OperandV2, StackItem} from "rainlang-0.1.2/src/abstract/BaseRainlangExtern.sol";
 import {LibConvert} from "rain-lib-typecast-0.1.0/src/LibConvert.sol";
 import {LibOpFtsoCurrentPriceUsd} from "../lib/op/LibOpFtsoCurrentPriceUsd.sol";
 import {LibOpFtsoCurrentPricePair} from "../lib/op/LibOpFtsoCurrentPricePair.sol";

--- a/src/abstract/FlareFtsoSubParser.sol
+++ b/src/abstract/FlareFtsoSubParser.sol
@@ -7,14 +7,14 @@ import {
     OperandV2,
     IParserToolingV1,
     ISubParserToolingV1
-} from "rainlang-0.1.1/src/abstract/BaseRainlangSubParser.sol";
+} from "rainlang-0.1.2/src/abstract/BaseRainlangSubParser.sol";
 import {
     OPCODE_FTSO_CURRENT_PRICE_USD,
     OPCODE_FTSO_CURRENT_PRICE_PAIR,
     OPCODE_SLFR_CURRENT_EXCHANGE_RATE
 } from "./FlareFtsoExtern.sol";
-import {LibSubParse, IInterpreterExternV4} from "rainlang-0.1.1/src/lib/parse/LibSubParse.sol";
-import {LibParseOperand} from "rainlang-0.1.1/src/lib/parse/LibParseOperand.sol";
+import {LibSubParse, IInterpreterExternV4} from "rainlang-0.1.2/src/lib/parse/LibSubParse.sol";
+import {LibParseOperand} from "rainlang-0.1.2/src/lib/parse/LibParseOperand.sol";
 import {LibConvert} from "rain-lib-typecast-0.1.0/src/LibConvert.sol";
 //Export this for convenience.
 //forge-lint: disable-next-line(mixed-case-function,unused-import)

--- a/test/src/concrete/FlareFtsoWords.ftsoCurrentPricePair.t.sol
+++ b/test/src/concrete/FlareFtsoWords.ftsoCurrentPricePair.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {OpTest, StackItem} from "rainlang-0.1.1/src/../test/abstract/OpTest.sol";
+import {OpTest, StackItem} from "rainlang-0.1.2/src/../test/abstract/OpTest.sol";
 import {FlareFtsoWords} from "src/concrete/FlareFtsoWords.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {Strings} from "@openzeppelin-contracts-5.6.1/utils/Strings.sol";

--- a/test/src/concrete/FlareFtsoWords.ftsoCurrentPriceUsd.t.sol
+++ b/test/src/concrete/FlareFtsoWords.ftsoCurrentPriceUsd.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {OpTest, StackItem} from "rainlang-0.1.1/src/../test/abstract/OpTest.sol";
+import {OpTest, StackItem} from "rainlang-0.1.2/src/../test/abstract/OpTest.sol";
 import {FlareFtsoWords} from "src/concrete/FlareFtsoWords.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {Strings} from "@openzeppelin-contracts-5.6.1/utils/Strings.sol";

--- a/test/src/concrete/FlareFtsoWords.sflrCurrentExchangeRate.t.sol
+++ b/test/src/concrete/FlareFtsoWords.sflrCurrentExchangeRate.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {OpTest, StackItem} from "rainlang-0.1.1/src/../test/abstract/OpTest.sol";
+import {OpTest, StackItem} from "rainlang-0.1.2/src/../test/abstract/OpTest.sol";
 import {FlareFtsoWords} from "src/concrete/FlareFtsoWords.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {Strings} from "@openzeppelin-contracts-5.6.1/utils/Strings.sol";


### PR DESCRIPTION
Picks up audit fixes (H01, M05, M06, L02, L03, I04, I06, I07, I08) from rainlang. Versioned import rewrites only — no source-level changes.