### PR TITLE
chore: drop stale rainlang-0.1.1 entry from remappings.txt

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -14,5 +14,4 @@ rain-sol-codegen-0.1.0/=dependencies/rain-sol-codegen-0.1.0/
 rain-solmem-0.1.3/=dependencies/rain-solmem-0.1.3/
 rain-string-0.2.0/=dependencies/rain-string-0.2.0/
 rain-tofu-erc20-decimals-0.1.1/=dependencies/rain-tofu-erc20-decimals-0.1.1/
-rainlang-0.1.1/=dependencies/rainlang-0.1.1/
 rainlang-0.1.2/=dependencies/rainlang-0.1.2/


### PR DESCRIPTION
soldeer left it behind on the 0.1.1 -> 0.1.2 bump; only 0.1.2 is installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated rainlang dependency to version 0.1.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->