### PR TITLE
ci: use reusable rainix-copy-artifacts

### DIFF
--- a/.github/workflows/git-clean.yaml
+++ b/.github/workflows/git-clean.yaml
@@ -1,33 +1,6 @@
 name: Git is clean
 on: [push]
 jobs:
-  git-clean:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: nixbuild/nix-quick-install-action@v30
-        with:
-          nix_conf: |
-            keep-env-derivations = true
-            keep-outputs = true
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 1G
-      - name: Install soldeer dependencies
-        if: hashFiles('soldeer.lock') != ''
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
-      - name: Regenerate meta files
-        run: nix run .#rain-flare-prelude
-      - name: Regenerate pointer artifacts
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge script ./script/BuildPointers.sol
-      - name: Format
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge fmt
-      - name: Assert committed artifacts match freshly built
-        run: |
-          if ! git diff --exit-code; then
-            echo "::error::Committed meta or pointer artifacts are stale. Regenerate and commit."
-            exit 1
-          fi
+  copy-artifacts:
+    uses: rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@main
+    secrets: inherit

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Regenerate committed meta artifacts that the rainix copy-artifacts reusable
+# diff-checks. Runs in the repo default devshell because `rain` is not in
+# rainix sol-shell.
+set -euo pipefail
+nix develop -c bash -euxo pipefail -c '
+  mkdir -p meta
+  forge script --silent ./script/BuildAuthoringMeta.sol
+  rain meta build -i <(cat ./meta/FlareFtsoSubParserAuthoringMeta.rain.meta) -m authoring-meta-v2 -t cbor -e deflate -l none -o meta/FlareFtsoWords.rain.meta
+'

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: LicenseRef-DCL-1.0
+# SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 # Regenerate committed meta artifacts that the rainix copy-artifacts reusable
 # diff-checks. Runs in the repo default devshell because `rain` is not in
 # rainix sol-shell.


### PR DESCRIPTION
Replace the bespoke `git-clean` workflow with the upstream `rainix-copy-artifacts` reusable. Adds `script/build.sh` so the reusable regenerates the authoring meta (needs `rain` CLI, absent from sol-shell) alongside `BuildPointers.sol`.