### PR TITLE
fix: conform flare to one-contract-per-.sol (unblocks static check)

### DIFF
--- a/test/lib/lts/FeedConsumer.sol
+++ b/test/lib/lts/FeedConsumer.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+import {LibFtsoV2LTS} from "src/lib/lts/LibFtsoV2LTS.sol";
+
+contract FeedConsumer {
+    function getFeedValue(bytes21 feedId, uint256 timeout) external payable returns (uint256) {
+        return LibFtsoV2LTS.ftsoV2LTSGetFeed(feedId, timeout);
+    }
+}

--- a/test/src/lib/lts/LibFtsoV2LTS.t.sol
+++ b/test/src/lib/lts/LibFtsoV2LTS.t.sol
@@ -11,12 +11,7 @@ import {IFeeCalculator} from "../../../../src/vendor/flare-smart-contracts-v2/us
 import {IGoverned, IGovernanceSettings} from "src/interface/IGoverned.sol";
 import {IGovernedFeeCalculator} from "src/interface/IGovernedFeeCalculator.sol";
 import {StalePrice} from "src/err/ErrFtso.sol";
-
-contract FeedConsumer {
-    function getFeedValue(bytes21 feedId, uint256 timeout) external payable returns (uint256) {
-        return LibFtsoV2LTS.ftsoV2LTSGetFeed(feedId, timeout);
-    }
-}
+import {FeedConsumer} from "test/lib/lts/FeedConsumer.sol";
 
 contract LibFtsoV2LTSTest is Test {
     function testFtsoV2LTSGetFeed() external {


### PR DESCRIPTION
The stricter rainix one-contract-per-file static check (`rainix-sol/static`, rainlanguage/rainix#214) now **fails on `main`** because some `.sol` files declare more than one top-level `contract`. That red blocks `main` and every flare PR, including #37.

## What was offending

A full sweep with the rainix `lib/sol-single-contract.sh` logic over all git-tracked `.sol` found exactly **one** offender:

- `test/src/lib/lts/LibFtsoV2LTS.t.sol` — declared **2** top-level contracts: the `FeedConsumer` test helper plus the `LibFtsoV2LTSTest` test.

No other tracked `.sol` declares more than one top-level `contract`/`abstract contract` (libraries/interfaces do not count).

## The fix (verbatim split, no logic change)

- Move `FeedConsumer` **verbatim** (byte-identical contract body) into its own file `test/lib/lts/FeedConsumer.sol`, adding only the SPDX header, pragma, and the `LibFtsoV2LTS` import the new file needs.
- Import `FeedConsumer` back into `LibFtsoV2LTS.t.sol` so the test still compiles.
- Each `.sol` now declares exactly one top-level `contract`.

No contract or function body was touched.

## Verification

- `sol_single_contract_check_tracked` over the whole repo: green (exit 0).
- `forge build`: clean (`Compiler run successful!`).
- `forge test`: **45 passed, 0 failed, 0 skipped** (incl. the 3 `LibFtsoV2LTSTest` tests that exercise the relocated `FeedConsumer`, and the on-chain fork tests).
- `forge fmt --check`: clean.

This greens the static check for `main` and all flare PRs (incl. #37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)