### PR TITLE
test(price-pair): pin mutation-coverage gaps in LibOpFtsoCurrentPricePair

### DIFF
--- a/test/src/lib/op/LibOpFtsoCurrentPricePair.t.sol
+++ b/test/src/lib/op/LibOpFtsoCurrentPricePair.t.sol
@@ -70,12 +70,12 @@ contract LibOpFtsoCurrentPricePairTest is FtsoTest {
         assertEq(outputs.length, 1);
         assertEq(
             StackItem.unwrap(outputs[0]),
-            Float.unwrap(LibDecimalFloat.div(LibDecimalFloat.packLossless(20e18, -18), LibDecimalFloat.packLossless(4e15, -18)))
+            Float.unwrap(
+                LibDecimalFloat.div(LibDecimalFloat.packLossless(20e18, -18), LibDecimalFloat.packLossless(4e15, -18))
+            )
         );
         // Sanity: the derived value is numerically 5000.
-        assertTrue(
-            LibDecimalFloat.eq(Float.wrap(StackItem.unwrap(outputs[0])), LibDecimalFloat.packLossless(5000, 0))
-        );
+        assertTrue(LibDecimalFloat.eq(Float.wrap(StackItem.unwrap(outputs[0])), LibDecimalFloat.packLossless(5000, 0)));
     }
 
     /// A zero base (first symbol) price yields a derived price of exactly zero,

--- a/test/src/lib/op/LibOpFtsoCurrentPricePair.t.sol
+++ b/test/src/lib/op/LibOpFtsoCurrentPricePair.t.sol
@@ -9,6 +9,7 @@ import {BLOCK_NUMBER} from "../registry/LibFlareContractRegistry.t.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {InactiveFtso} from "src/err/ErrFtso.sol";
 import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
+import {DivisionByZero} from "rain-math-float-0.1.1/src/error/ErrDecimalFloat.sol";
 
 contract LibOpFtsoCurrentPricePairTest is FtsoTest {
     function externalRun(OperandV2 operand, StackItem[] memory inputs)
@@ -18,6 +19,105 @@ contract LibOpFtsoCurrentPricePairTest is FtsoTest {
         returns (StackItem[] memory)
     {
         return LibOpFtsoCurrentPricePair.run(operand, inputs);
+    }
+
+    /// Fully mock a single FTSO (registry lookup, active flag, finalized price
+    /// details and the price-with-decimals tuple) with a fixed, non-stale price
+    /// so a pair run is deterministic and fork-independent. `currentTime` is
+    /// assumed already warped to a value at which `priceTimestamp` is not stale.
+    function mockOneFtso(address ftso, string memory symbol, uint256 price, uint256 decimals, uint256 priceTimestamp)
+        internal
+    {
+        mockFtsoRegistry(ftso, symbol);
+        activateFtso(ftso);
+
+        PriceDetails memory priceDetails;
+        priceDetails.price = price;
+        priceDetails.priceTimestamp = priceTimestamp;
+        priceDetails.priceFinalizationType = uint8(IFtso.PriceFinalizationType.WEIGHTED_MEDIAN);
+        priceDetails.lastPriceEpochFinalizationType = uint8(IFtso.PriceFinalizationType.WEIGHTED_MEDIAN);
+        mockPriceDetails(ftso, priceDetails);
+
+        CurrentPrice memory currentPrice;
+        currentPrice.price = price;
+        currentPrice.timestamp = priceTimestamp;
+        currentPrice.decimals = decimals;
+        mockPrice(ftso, currentPrice);
+    }
+
+    /// A fully-mocked, deterministic pair run. Pins that the derived price is
+    /// exactly base/quote = symbolA-price / symbolB-price, with each USD price
+    /// normalized by its own (independent) decimals before the division. Uses
+    /// distinct decimals per leg so a swapped numerator/denominator or a
+    /// mis-aligned decimal would change the result.
+    function testRunPairDerivationExact() external {
+        // base: 2000 with 2 decimals => 20.00
+        // quote: 4 with 3 decimals  => 0.004
+        // derived = 20 / 0.004 = 5000
+        uint256 priceTimestamp = 1000;
+        vm.warp(priceTimestamp + 10);
+
+        mockRegistry(2);
+        mockOneFtso(FTSO_A, "AAA", 2000, 2, priceTimestamp);
+        mockOneFtso(FTSO_B, "BBB", 4, 3, priceTimestamp);
+
+        StackItem[] memory inputs = new StackItem[](3);
+        inputs[0] = StackItem.wrap(bytes32(IntOrAString.unwrap(LibIntOrAString.fromStringV3("AAA"))));
+        inputs[1] = StackItem.wrap(bytes32(IntOrAString.unwrap(LibIntOrAString.fromStringV3("BBB"))));
+        inputs[2] = StackItem.wrap(Float.unwrap(LibDecimalFloat.fromFixedDecimalLosslessPacked(3600, 0)));
+
+        StackItem[] memory outputs = this.externalRun(OperandV2.wrap(0), inputs);
+        assertEq(outputs.length, 1);
+        assertEq(
+            StackItem.unwrap(outputs[0]),
+            Float.unwrap(LibDecimalFloat.div(LibDecimalFloat.packLossless(20e18, -18), LibDecimalFloat.packLossless(4e15, -18)))
+        );
+        // Sanity: the derived value is numerically 5000.
+        assertTrue(
+            LibDecimalFloat.eq(Float.wrap(StackItem.unwrap(outputs[0])), LibDecimalFloat.packLossless(5000, 0))
+        );
+    }
+
+    /// A zero base (first symbol) price yields a derived price of exactly zero,
+    /// since 0 / quote = 0.
+    function testRunPairZeroBaseIsZero() external {
+        uint256 priceTimestamp = 1000;
+        vm.warp(priceTimestamp + 10);
+
+        mockRegistry(2);
+        mockOneFtso(FTSO_A, "AAA", 0, 2, priceTimestamp);
+        mockOneFtso(FTSO_B, "BBB", 4, 3, priceTimestamp);
+
+        StackItem[] memory inputs = new StackItem[](3);
+        inputs[0] = StackItem.wrap(bytes32(IntOrAString.unwrap(LibIntOrAString.fromStringV3("AAA"))));
+        inputs[1] = StackItem.wrap(bytes32(IntOrAString.unwrap(LibIntOrAString.fromStringV3("BBB"))));
+        inputs[2] = StackItem.wrap(Float.unwrap(LibDecimalFloat.fromFixedDecimalLosslessPacked(3600, 0)));
+
+        StackItem[] memory outputs = this.externalRun(OperandV2.wrap(0), inputs);
+        assertEq(outputs.length, 1);
+        assertTrue(LibDecimalFloat.isZero(Float.wrap(StackItem.unwrap(outputs[0]))));
+    }
+
+    /// A zero quote (second symbol) price MUST revert with DivisionByZero rather
+    /// than produce a garbage or infinite derived price. The quote is the
+    /// denominator, so its zeroing is the dangerous case.
+    function testRunPairZeroQuoteReverts() external {
+        uint256 priceTimestamp = 1000;
+        vm.warp(priceTimestamp + 10);
+
+        mockRegistry(2);
+        mockOneFtso(FTSO_A, "AAA", 2000, 2, priceTimestamp);
+        mockOneFtso(FTSO_B, "BBB", 0, 3, priceTimestamp);
+
+        StackItem[] memory inputs = new StackItem[](3);
+        inputs[0] = StackItem.wrap(bytes32(IntOrAString.unwrap(LibIntOrAString.fromStringV3("AAA"))));
+        inputs[1] = StackItem.wrap(bytes32(IntOrAString.unwrap(LibIntOrAString.fromStringV3("BBB"))));
+        inputs[2] = StackItem.wrap(Float.unwrap(LibDecimalFloat.fromFixedDecimalLosslessPacked(3600, 0)));
+
+        // The error carries the numerator (base price) coefficient/exponent:
+        // base price 2000 with 2 decimals => (2000, -2).
+        vm.expectRevert(abi.encodeWithSelector(DivisionByZero.selector, int256(2000), int256(-2)));
+        this.externalRun(OperandV2.wrap(0), inputs);
     }
 
     function testIntegrity(OperandV2 operand, uint256 inputs, uint256 outputs) external pure {


### PR DESCRIPTION
Closes #73

Adds 3 mocked, fork-independent discriminating tests to `test/src/lib/op/LibOpFtsoCurrentPricePair.t.sol` that kill all 3 surviving mutants:

- `testRunPairDerivationExact` — distinct decimals per leg (base 20.00@2dp, quote 0.004@3dp → 5000); kills numerator/denominator swap and decimal mis-alignment mutations
- `testRunPairZeroBaseIsZero` — 0 base price → derived price exactly zero
- `testRunPairZeroQuoteReverts` — 0 quote (denominator) → `DivisionByZero` with exact coefficient+exponent in the error

Each test independently kills the `priceA.div(priceB) → priceB.div(priceA)` direction mutation without requiring the live fork.

Suite green (10/3/4). Tests-only change, no bytecode impact.

Co-Authored-By: Claude <noreply@anthropic.com>