### PR TITLE
Add missing view to governanceSettings() in IGoverned (closes #101)

### DIFF
--- a/src/interface/IGoverned.sol
+++ b/src/interface/IGoverned.sol
@@ -7,7 +7,7 @@ import {IGovernanceSettings} from "../vendor/flare-smart-contracts/userInterface
 interface IGoverned {
     function governance() external view returns (address);
 
-    function governanceSettings() external returns (IGovernanceSettings);
+    function governanceSettings() external view returns (IGovernanceSettings);
 
     function executeGovernanceCall(bytes4 selector) external;
 }


### PR DESCRIPTION
## Summary
- `governanceSettings()` in `IGoverned.sol` was missing `view`, contradicting Flare's canonical `IGovernedBase` and the sibling `governance()` getter (which is already `view`).
- One-line fix: add `view` to match the canonical interface.

## Test plan
- `forge build` compiles cleanly.
- Existing fork test at `test/src/lib/lts/LibFtsoV2LTS.t.sol:43` already exercises the function.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)