### PR TITLE
Fix pervasive SLFR typo: rename to SFLR across source tree

### DIFF
--- a/src/abstract/FlareFtsoExtern.sol
+++ b/src/abstract/FlareFtsoExtern.sol
@@ -6,7 +6,7 @@ import {BaseRainlangExtern, OperandV2, StackItem} from "rainlang-0.1.2/src/abstr
 import {LibConvert} from "rain-lib-typecast-0.1.0/src/LibConvert.sol";
 import {LibOpFtsoCurrentPriceUsd} from "../lib/op/LibOpFtsoCurrentPriceUsd.sol";
 import {LibOpFtsoCurrentPricePair} from "../lib/op/LibOpFtsoCurrentPricePair.sol";
-import {LibOpSLFRCurrentExchangeRate} from "../lib/op/LibOpSFlrCurrentExchangeRate.sol";
+import {LibOpSFLRCurrentExchangeRate} from "../lib/op/LibOpSFlrCurrentExchangeRate.sol";
 
 import {INTEGRITY_FUNCTION_POINTERS, OPCODE_FUNCTION_POINTERS} from "../generated/FlareFtsoWords.pointers.sol";
 
@@ -14,8 +14,8 @@ import {INTEGRITY_FUNCTION_POINTERS, OPCODE_FUNCTION_POINTERS} from "../generate
 uint256 constant OPCODE_FTSO_CURRENT_PRICE_USD = 0;
 /// @dev Index into the function pointers array for the current pair price.
 uint256 constant OPCODE_FTSO_CURRENT_PRICE_PAIR = 1;
-/// @dev Index into the function pointers array for the SLFR exchange rate.
-uint256 constant OPCODE_SLFR_CURRENT_EXCHANGE_RATE = 2;
+/// @dev Index into the function pointers array for the SFLR exchange rate.
+uint256 constant OPCODE_SFLR_CURRENT_EXCHANGE_RATE = 2;
 /// @dev The number of function pointers in the array.
 uint256 constant OPCODE_FUNCTION_POINTERS_LENGTH = 3;
 
@@ -55,7 +55,7 @@ abstract contract FlareFtsoExtern is BaseRainlangExtern {
         view returns (StackItem[] memory)[](OPCODE_FUNCTION_POINTERS_LENGTH);
         fs[OPCODE_FTSO_CURRENT_PRICE_USD] = LibOpFtsoCurrentPriceUsd.run;
         fs[OPCODE_FTSO_CURRENT_PRICE_PAIR] = LibOpFtsoCurrentPricePair.run;
-        fs[OPCODE_SLFR_CURRENT_EXCHANGE_RATE] = LibOpSLFRCurrentExchangeRate.run;
+        fs[OPCODE_SFLR_CURRENT_EXCHANGE_RATE] = LibOpSFLRCurrentExchangeRate.run;
 
         uint256[] memory pointers;
         assembly ("memory-safe") {
@@ -73,7 +73,7 @@ abstract contract FlareFtsoExtern is BaseRainlangExtern {
         pure returns (uint256, uint256)[](OPCODE_FUNCTION_POINTERS_LENGTH);
         fs[OPCODE_FTSO_CURRENT_PRICE_USD] = LibOpFtsoCurrentPriceUsd.integrity;
         fs[OPCODE_FTSO_CURRENT_PRICE_PAIR] = LibOpFtsoCurrentPricePair.integrity;
-        fs[OPCODE_SLFR_CURRENT_EXCHANGE_RATE] = LibOpSLFRCurrentExchangeRate.integrity;
+        fs[OPCODE_SFLR_CURRENT_EXCHANGE_RATE] = LibOpSFLRCurrentExchangeRate.integrity;
 
         uint256[] memory pointers;
         assembly ("memory-safe") {

--- a/src/abstract/FlareFtsoSubParser.sol
+++ b/src/abstract/FlareFtsoSubParser.sol
@@ -11,7 +11,7 @@ import {
 import {
     OPCODE_FTSO_CURRENT_PRICE_USD,
     OPCODE_FTSO_CURRENT_PRICE_PAIR,
-    OPCODE_SLFR_CURRENT_EXCHANGE_RATE
+    OPCODE_SFLR_CURRENT_EXCHANGE_RATE
 } from "./FlareFtsoExtern.sol";
 import {LibSubParse, IInterpreterExternV4} from "rainlang-0.1.2/src/lib/parse/LibSubParse.sol";
 import {LibParseOperand} from "rainlang-0.1.2/src/lib/parse/LibParseOperand.sol";
@@ -137,7 +137,7 @@ abstract contract FlareFtsoSubParser is BaseRainlangSubParser {
     {
         //slither-disable-next-line unused-return
         return LibSubParse.subParserExtern(
-            IInterpreterExternV4(extern()), constantsHeight, ioByte, operand, OPCODE_SLFR_CURRENT_EXCHANGE_RATE
+            IInterpreterExternV4(extern()), constantsHeight, ioByte, operand, OPCODE_SFLR_CURRENT_EXCHANGE_RATE
         );
     }
 }

--- a/src/lib/op/LibOpSFlrCurrentExchangeRate.sol
+++ b/src/lib/op/LibOpSFlrCurrentExchangeRate.sol
@@ -6,9 +6,9 @@ import {OperandV2, StackItem} from "rain-interpreter-interface-0.1.0/src/interfa
 import {LibSceptreStakedFlare} from "../sflr/LibSceptreStakedFlare.sol";
 import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
 
-/// @title LibOpSLFRCurrentExchangeRate
+/// @title LibOpSFLRCurrentExchangeRate
 /// Implements the `sflrCurrentExchangeRate` externed opcode.
-library LibOpSLFRCurrentExchangeRate {
+library LibOpSFLRCurrentExchangeRate {
     /// Extern integrity for getting the current exchange rate of FLR to SFLR.
     function integrity(OperandV2, uint256, uint256) internal pure returns (uint256, uint256) {
         return (0, 1);


### PR DESCRIPTION
## Summary
- The asset is Sceptre Staked FLR, abbreviated **SFLR**. The transposed typo **SLFR** appeared in three places: the library name (`LibOpSLFRCurrentExchangeRate`), the constant (`OPCODE_SLFR_CURRENT_EXCHANGE_RATE`), and the NatSpec comment.
- Renames all occurrences across `FlareFtsoExtern.sol`, `FlareFtsoSubParser.sol`, and `LibOpSFlrCurrentExchangeRate.sol`.

## Test plan
- `forge build` — compiles cleanly (14 files recompiled, no errors).

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)