### PR TITLE
Document IFtso re-export intent in LibFlareContractRegistry

### DIFF
--- a/src/lib/registry/LibFlareContractRegistry.sol
+++ b/src/lib/registry/LibFlareContractRegistry.sol
@@ -6,6 +6,8 @@ import {FtsoV2Interface} from "../../vendor/flare-smart-contracts-v2/userInterfa
 import {IFeeCalculator} from "../../vendor/flare-smart-contracts-v2/userInterfaces/IFeeCalculator.sol";
 import {IFtsoRegistry} from "../../vendor/flare-smart-contracts/userInterfaces/IFtsoRegistry.sol";
 import {IFlareContractRegistry} from "../../vendor/flare-smart-contracts/userInterfaces/IFlareContractRegistry.sol";
+// Re-exported so that files importing this registry lib also get IFtso without
+// a separate vendor import. Tests use IFtso.PriceFinalizationType and selectors.
 //forge-lint: disable-next-line(unused-import)
 import {IFtso} from "../../vendor/flare-smart-contracts/userInterfaces/IFtso.sol";
 


### PR DESCRIPTION
## Summary
- `LibFlareContractRegistry.sol` imports `IFtso` with only a lint suppression and no explanation.
- Investigation shows the import IS intentional: test files (`LibOpFtsoCurrentPriceUsd.t.sol`) import `IFtso` via this file to get `IFtso.PriceFinalizationType` and selectors without a separate vendor import path.
- Adds a two-line comment documenting the re-export intent, so the suppression's purpose is explicit.

## Test plan
- `forge build` — compiles cleanly.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)