### PR TITLE
Consolidate fork BLOCK_NUMBER pins into ForkConstants.sol

### DIFF
--- a/test/fork/ForkConstants.sol
+++ b/test/fork/ForkConstants.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity =0.8.25;
+
+/// @dev Canonical Flare mainnet block for registry, FTSO, sFLR, and LTS tests.
+uint256 constant BLOCK_NUMBER = 31843105;
+
+/// @dev Canonical Flare mainnet block for the dinero flrETH tests, which
+/// exercise state at a different height than the FTSO/sFLR suite.
+uint256 constant FLRETH_BLOCK_NUMBER = 37796420;

--- a/test/src/concrete/FlareFtsoWords.sflrCurrentExchangeRate.t.sol
+++ b/test/src/concrete/FlareFtsoWords.sflrCurrentExchangeRate.t.sol
@@ -7,8 +7,7 @@ import {FlareFtsoWords} from "src/concrete/FlareFtsoWords.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {Strings} from "@openzeppelin-contracts-5.6.1/utils/Strings.sol";
 import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
-
-uint256 constant BLOCK_NUMBER = 31843105;
+import {BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 
 contract FlareSflrCurrentExchangeRateTest is OpTest {
     using Strings for address;

--- a/test/src/lib/flreth/LibDineroFlrEth.t.sol
+++ b/test/src/lib/flreth/LibDineroFlrEth.t.sol
@@ -5,12 +5,11 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {LibDineroFlrEth} from "src/lib/flreth/LibDineroFlrEth.sol";
-
-uint256 constant BLOCK_NUMBER = 37796420;
+import {FLRETH_BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 
 contract LibDineroFlrEthTest is Test {
     constructor() {
-        vm.createSelectFork(LibFork.rpcUrlFlare(vm), BLOCK_NUMBER);
+        vm.createSelectFork(LibFork.rpcUrlFlare(vm), FLRETH_BLOCK_NUMBER);
     }
 
     function testGetETHPerFLRETH18() external view {

--- a/test/src/lib/registry/LibFlareContractRegistry.t.sol
+++ b/test/src/lib/registry/LibFlareContractRegistry.t.sol
@@ -5,8 +5,7 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {LibFlareContractRegistry, IFtsoRegistry} from "src/lib/registry/LibFlareContractRegistry.sol";
-
-uint256 constant BLOCK_NUMBER = 31843105;
+import {BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 
 contract LibFlareContractRegistryTest is Test {
     constructor() {

--- a/test/src/lib/sflr/LibSceptreStakedFlare.t.sol
+++ b/test/src/lib/sflr/LibSceptreStakedFlare.t.sol
@@ -5,8 +5,7 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {LibSceptreStakedFlare} from "src/lib/sflr/LibSceptreStakedFlare.sol";
-
-uint256 constant BLOCK_NUMBER = 31843105;
+import {BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 
 contract LibSceptreStakedFlareTest is Test {
     constructor() {


### PR DESCRIPTION
## Summary
- Four test files independently declared `BLOCK_NUMBER` as either `31843105` (registry/sFLR/concrete) or `37796420` (flrETH). A re-pin in one couldn't be seen by the others.
- Creates `test/fork/ForkConstants.sol` with `BLOCK_NUMBER = 31843105` and `FLRETH_BLOCK_NUMBER = 37796420` as the canonical source.
- Updates the four files to import from `ForkConstants.sol`. Files that already imported via `LibFlareContractRegistry.t.sol` continue to work unchanged (Solidity re-exports the imported symbol).

## Test plan
- `forge build` — compiles cleanly (20 files recompiled, no errors).

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)