### PR TITLE
Add explicit fuzz config to foundry.toml (runs=1000, seed=0x1)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,6 +8,10 @@ libs = ['dependencies']
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 
 solc = "0.8.25"
+
+[profile.default.fuzz]
+runs = 1000
+seed = "0x1"
 optimizer = true
 optimizer_runs = 1000
 evm_version = "cancun"

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,9 +9,6 @@ libs = ['dependencies']
 
 solc = "0.8.25"
 
-[profile.default.fuzz]
-runs = 1000
-seed = "0x1"
 optimizer = true
 optimizer_runs = 1000
 evm_version = "cancun"
@@ -22,6 +19,10 @@ fs_permissions = [
   { access = "read-write", path = "src/generated" },
   { access = "read-write", path = "meta" },
 ]
+
+[profile.default.fuzz]
+runs = 1000
+seed = "0x1"
 
 [dependencies]
 forge-std = "1.16.1"


### PR DESCRIPTION
## Summary
- `foundry.toml` had no `[fuzz]` section, so run count and seed fell back to undocumented Foundry defaults, making CI non-deterministic and unreproducible.
- Adds `runs = 1000` and `seed = "0x1"` to pin coverage depth and make CI deterministic.

## Test plan
- `forge build` — compiles cleanly.
- Per-test `/// forge-config: default.fuzz.runs = N` overrides remain available for individual heavier suites.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)