### PR TITLE
Pin CI reusable workflows to current rainix main SHA

### DIFF
--- a/.github/workflows/git-clean.yaml
+++ b/.github/workflows/git-clean.yaml
@@ -2,5 +2,5 @@ name: Git is clean
 on: [push]
 jobs:
   copy-artifacts:
-    uses: rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@main
+    uses: rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@f6bca081825f0fed57a8885e58feb4296307da20
     secrets: inherit

--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -10,7 +10,7 @@ on:
           - flare-ftso-words
 jobs:
   deploy:
-    uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@main
+    uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@f6bca081825f0fed57a8885e58feb4296307da20
     with:
       suite: ${{ inputs.suite }}
     secrets: inherit

--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   release:
-    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
+    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@f6bca081825f0fed57a8885e58feb4296307da20
     with:
       soldeer-package: rain-flare
     secrets: inherit

--- a/.github/workflows/rainix-sol.yaml
+++ b/.github/workflows/rainix-sol.yaml
@@ -2,5 +2,5 @@ name: rainix-sol
 on: [push]
 jobs:
   rainix-sol:
-    uses: rainlanguage/rainix/.github/workflows/rainix-sol.yaml@main
+    uses: rainlanguage/rainix/.github/workflows/rainix-sol.yaml@f6bca081825f0fed57a8885e58feb4296307da20
     secrets: inherit


### PR DESCRIPTION
## Summary
- All 4 workflow files called reusable workflows with `@main`, which tracks a moving ref — CI behaviour silently changes whenever rainix main advances.
- Pinned each to the current rainix main SHA `f6bca081825f0fed57a8885e58feb4296307da20` so builds are reproducible and any future rainix change requires an explicit bump here.

## Files changed
- `.github/workflows/rainix-sol.yaml`
- `.github/workflows/manual-sol-artifacts.yaml`
- `.github/workflows/package-release.yaml`
- `.github/workflows/git-clean.yaml`

## Test plan
- YAML-only change; no Solidity code or test modifications.
- CI will run against the pinned SHA on push.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)