### PR TITLE
Fix copy-pasted NatSpec on sFlrCurrentExchangeRateSubParser

### DIFF
--- a/src/abstract/FlareFtsoSubParser.sol
+++ b/src/abstract/FlareFtsoSubParser.sol
@@ -128,7 +128,7 @@ abstract contract FlareFtsoSubParser is BaseRainlangSubParser {
     }
 
     /// Thin wrapper around LibSubParse.subParserExtern that provides the extern
-    /// address and index of the current pair price opcode index in the extern.
+    /// address and index of the sFLR current exchange rate opcode index in the extern.
     //slither-disable-next-line dead-code
     function sFlrCurrentExchangeRateSubParser(uint256 constantsHeight, uint256 ioByte, OperandV2 operand)
         internal


### PR DESCRIPTION
## Summary
The NatSpec comment on `sFlrCurrentExchangeRateSubParser` (FlareFtsoSubParser.sol) was copied verbatim from `ftsoCurrentPricePairSubParser` and still read "current pair price opcode". Corrected it to "sFLR current exchange rate opcode".

## Test plan
- NatSpec-only change. `forge build` compiles cleanly.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)