### PR TITLE
test: fuzz negative and fractional Float timeout inputs to run()

### DIFF
--- a/test/src/lib/op/LibOpFtsoCurrentPriceUsd.t.sol
+++ b/test/src/lib/op/LibOpFtsoCurrentPriceUsd.t.sol
@@ -10,6 +10,10 @@ import {LibFork} from "test/fork/LibFork.sol";
 import {BLOCK_NUMBER} from "../registry/LibFlareContractRegistry.t.sol";
 import {InactiveFtso, PriceNotFinalized, StalePrice, DecimalsTooLarge} from "src/err/ErrFtso.sol";
 import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
+import {
+    NegativeFixedDecimalConversion,
+    LossyConversionFromFloat
+} from "rain-math-float-0.1.1/src/error/ErrDecimalFloat.sol";
 
 contract LibOpFtsoCurrentPriceUsdTest is FtsoTest {
     function externalRun(OperandV2 operand, StackItem[] memory inputs)
@@ -191,6 +195,34 @@ contract LibOpFtsoCurrentPriceUsdTest is FtsoTest {
         inputs[1] = StackItem.wrap(Float.unwrap(LibDecimalFloat.fromFixedDecimalLosslessPacked(timeout, 0)));
 
         vm.expectRevert(abi.encodeWithSelector(PriceNotFinalized.selector, priceDetails.priceFinalizationType));
+        this.externalRun(operand, inputs);
+    }
+
+    /// A negative Float timeout must revert with NegativeFixedDecimalConversion.
+    function testRunNegativeTimeoutReverts(OperandV2 operand, string memory symbol, int256 coeff, int32 exp)
+        external
+    {
+        vm.assume(bytes(symbol).length <= 31);
+        coeff = bound(coeff, type(int224).min, -1);
+        uint256 intSymbol = IntOrAString.unwrap(LibIntOrAString.fromStringV3(symbol));
+        StackItem[] memory inputs = new StackItem[](2);
+        inputs[0] = StackItem.wrap(bytes32(intSymbol));
+        inputs[1] = StackItem.wrap(Float.unwrap(LibDecimalFloat.packLossless(coeff, int256(exp))));
+        vm.expectRevert(abi.encodeWithSelector(NegativeFixedDecimalConversion.selector, coeff, int256(exp)));
+        this.externalRun(operand, inputs);
+    }
+
+    /// A fractional (non-integer) Float timeout must revert with LossyConversionFromFloat.
+    function testRunFractionalTimeoutReverts(OperandV2 operand, string memory symbol, int256 coeff) external {
+        vm.assume(bytes(symbol).length <= 31);
+        coeff = bound(coeff, 1, int256(type(int224).max));
+        vm.assume(coeff % 10 != 0);
+        uint256 intSymbol = IntOrAString.unwrap(LibIntOrAString.fromStringV3(symbol));
+        StackItem[] memory inputs = new StackItem[](2);
+        inputs[0] = StackItem.wrap(bytes32(intSymbol));
+        // exponent -1 with a non-multiple-of-10 coefficient is always fractional
+        inputs[1] = StackItem.wrap(Float.unwrap(LibDecimalFloat.packLossless(coeff, -1)));
+        vm.expectRevert(abi.encodeWithSelector(LossyConversionFromFloat.selector, coeff, int256(-1)));
         this.externalRun(operand, inputs);
     }
 

--- a/test/src/lib/op/LibOpFtsoCurrentPriceUsd.t.sol
+++ b/test/src/lib/op/LibOpFtsoCurrentPriceUsd.t.sol
@@ -199,9 +199,7 @@ contract LibOpFtsoCurrentPriceUsdTest is FtsoTest {
     }
 
     /// A negative Float timeout must revert with NegativeFixedDecimalConversion.
-    function testRunNegativeTimeoutReverts(OperandV2 operand, string memory symbol, int256 coeff, int32 exp)
-        external
-    {
+    function testRunNegativeTimeoutReverts(OperandV2 operand, string memory symbol, int256 coeff, int32 exp) external {
         vm.assume(bytes(symbol).length <= 31);
         coeff = bound(coeff, type(int224).min, -1);
         uint256 intSymbol = IntOrAString.unwrap(LibIntOrAString.fromStringV3(symbol));


### PR DESCRIPTION
## Summary

Every existing timeout test constructed the timeout from a non-negative integer via `fromFixedDecimalLosslessPacked(timeout, 0)`. No test ever passed a negative or fractional Float directly — the two reachable rainlang-author failure modes.

Adds two fuzz tests using `packLossless(coeff, exp)` to produce Float values directly:

- `testRunNegativeTimeoutReverts` — bounds `coeff ∈ [int224.min, -1]`, any `int32` exponent; asserts `NegativeFixedDecimalConversion(coeff, exp)` is thrown.
- `testRunFractionalTimeoutReverts` — positive `coeff` not divisible by 10, exponent `-1` (guaranteed fractional at 0 decimals); asserts `LossyConversionFromFloat(coeff, -1)` is thrown.

Both use `abi.encodeWithSelector(...)` with the exact known arguments rather than a bare selector, since Foundry's `expectRevert(bytes4)` requires an exact 4-byte revert payload.

Closes #83

Co-Authored-By: Claude <noreply@anthropic.com>