### PR TITLE
docs: add NatSpec to ftsoCurrentPriceUsd

### DIFF
--- a/src/lib/price/LibFtsoCurrentPriceUsd.sol
+++ b/src/lib/price/LibFtsoCurrentPriceUsd.sol
@@ -7,6 +7,21 @@ import {InactiveFtso, PriceNotFinalized, StalePrice, InconsistentFtso} from "../
 import {IFtso} from "../../vendor/flare-smart-contracts/userInterfaces/IFtso.sol";
 
 library LibFtsoCurrentPriceUsd {
+    /// @dev Fetches the current USD price and its native decimals for an FTSO
+    /// symbol from the Flare contract registry. The returned price is NOT
+    /// normalized; callers MUST normalize to their required precision (e.g. 18
+    /// decimals) and MUST guard against unexpectedly large decimals before
+    /// scaling (see `DecimalsTooLarge` in the caller).
+    /// @param symbol The FTSO asset symbol to price, e.g. "ETH".
+    /// @param timeout Max age in seconds before the price is considered stale.
+    /// @return price The FTSO USD price, scaled by 10**decimals.
+    /// @return decimals The number of decimals the FTSO uses for `price`.
+    /// @custom:error InactiveFtso The FTSO reports itself as inactive.
+    /// @custom:error PriceNotFinalized The price was not finalized by weighted
+    /// median or trusted addresses (other modes copy an earlier epoch).
+    /// @custom:error InconsistentFtso The two FTSO reads disagreed on price or
+    /// timestamp, indicating a bug in the FTSO.
+    /// @custom:error StalePrice The price timestamp is older than `timeout` seconds.
     function ftsoCurrentPriceUsd(string memory symbol, uint256 timeout) internal view returns (uint256, uint256) {
         // Fetch the FTSO from the registry.
         IFtsoRegistry ftsoRegistry = LibFlareContractRegistry.getFtsoRegistry();


### PR DESCRIPTION
## Summary

`LibFtsoCurrentPriceUsd.ftsoCurrentPriceUsd` — the library's only function — had zero NatSpec. The two unnamed return values (`price`, `decimals`) are easy to confuse, and the un-normalized/un-bounded-decimals contract (callers must guard via `DecimalsTooLarge`) was undocumented.

Adds:
- `@dev` description explaining the price is un-normalized and callers must guard decimals
- `@param symbol` and `@param timeout`
- `@return price` and `@return decimals`
- `@custom:error` entries for all four revert paths (`InactiveFtso`, `PriceNotFinalized`, `InconsistentFtso`, `StalePrice`)

Closes #96

Co-Authored-By: Claude <noreply@anthropic.com>