### PR TITLE
docs: fix NatSpec on run() for revert conditions and rate direction

### DIFF
--- a/src/lib/op/LibOpFtsoCurrentPricePair.sol
+++ b/src/lib/op/LibOpFtsoCurrentPricePair.sol
@@ -41,9 +41,10 @@ library LibOpFtsoCurrentPricePair {
     /// @return outputs The outputs of the operation.
     ///   0. The derived price of the two assets as a Float representing the
     ///      base/quote ratio (priceA / priceB), decimal-exponent encoded.
-    /// @custom:error Reverts with a divide-by-zero panic if the quote (second)
-    ///   symbol resolves to a zero price via `LibDecimalFloat.div`. Also
-    ///   propagates all `ftsoCurrentPriceUsd` errors for each fetch.
+    /// @custom:error Reverts with `DivisionByZero` (a typed error from
+    ///   rain.math.float) if the quote (second) symbol resolves to a zero price
+    ///   via `LibDecimalFloat.div`. Also propagates all `ftsoCurrentPriceUsd`
+    ///   errors for each fetch.
     function run(OperandV2 operand, StackItem[] memory inputs) internal view returns (StackItem[] memory) {
         uint256 symbolA;
         assembly ("memory-safe") {

--- a/src/lib/op/LibOpFtsoCurrentPricePair.sol
+++ b/src/lib/op/LibOpFtsoCurrentPricePair.sol
@@ -39,7 +39,11 @@ library LibOpFtsoCurrentPricePair {
     ///   2. The timeout in seconds to invalidate prices after if the FTSO stops
     ///      updating for some time.
     /// @return outputs The outputs of the operation.
-    ///   0. The derived price of the two assets, normalized to 18 decimals.
+    ///   0. The derived price of the two assets as a Float representing the
+    ///      base/quote ratio (priceA / priceB), decimal-exponent encoded.
+    /// @custom:error Reverts with a divide-by-zero panic if the quote (second)
+    ///   symbol resolves to a zero price via `LibDecimalFloat.div`. Also
+    ///   propagates all `ftsoCurrentPriceUsd` errors for each fetch.
     function run(OperandV2 operand, StackItem[] memory inputs) internal view returns (StackItem[] memory) {
         uint256 symbolA;
         assembly ("memory-safe") {

--- a/src/lib/op/LibOpFtsoCurrentPriceUsd.sol
+++ b/src/lib/op/LibOpFtsoCurrentPriceUsd.sol
@@ -35,7 +35,11 @@ library LibOpFtsoCurrentPriceUsd {
     ///   1. The timeout in seconds to invalidate prices after if the FTSO stops
     ///      updating for some time.
     /// @return outputs The outputs of the operation. Always 1 item.
-    ///   0. The price of the asset in USD, normalized to 18 decimals.
+    ///   0. The price of the asset in USD, as a Float.
+    /// @custom:error DecimalsTooLarge Reverts if the FTSO reports more than
+    ///   `type(uint8).max` decimals. Also propagates `InactiveFtso`,
+    ///   `PriceNotFinalized`, `StalePrice`, and `InconsistentFtso` from
+    ///   `LibFtsoCurrentPriceUsd.ftsoCurrentPriceUsd`.
     function run(OperandV2, StackItem[] memory inputs) internal view returns (StackItem[] memory) {
         IntOrAString symbol;
         Float timeout;

--- a/src/lib/op/LibOpSFlrCurrentExchangeRate.sol
+++ b/src/lib/op/LibOpSFlrCurrentExchangeRate.sol
@@ -9,13 +9,18 @@ import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFl
 /// @title LibOpSLFRCurrentExchangeRate
 /// Implements the `sflrCurrentExchangeRate` externed opcode.
 library LibOpSLFRCurrentExchangeRate {
-    /// Extern integrity for getting the current exchange rate of FLR to SFLR.
+    /// Extern integrity for getting the current sFLR-per-FLR exchange rate.
+    /// Takes 0 inputs, produces 1 output.
     function integrity(OperandV2, uint256, uint256) internal pure returns (uint256, uint256) {
         return (0, 1);
     }
 
-    /// Extern implementation for reading the current exchange rate of FLR to sFLR
+    /// Extern implementation for reading the current sFLR-per-FLR exchange rate
     /// based on directly reading the underlying assets self-reported by the sFLR contract.
+    /// @return outputs The outputs of the operation. Always 1 item.
+    ///   0. The current sFLR-per-FLR exchange rate as a Float, i.e.
+    ///      `getSharesByPooledFlr(1e18)` divided by 1e18. A value less than 1
+    ///      means 1 FLR yields fewer than 1 sFLR share (typical after accrual).
     function run(OperandV2, StackItem[] memory) internal view returns (StackItem[] memory) {
         uint256 rate18 = LibSceptreStakedFlare.getSFLRPerFLR18();
         Float rateFloat = LibDecimalFloat.fromFixedDecimalLosslessPacked(rate18, 18);


### PR DESCRIPTION
## Summary

Three related NatSpec gaps across the opcode libraries:

**#93 — `LibOpFtsoCurrentPriceUsd.run()`**: The `@return` was already present but never mentioned reverts. Adds `@custom:error` listing `DecimalsTooLarge` (the local guard) and the four propagated errors from `LibFtsoCurrentPriceUsd`. Also corrects the `@return` description from "normalized to 18 decimals" to "as a Float" (the output is a decimal-exponent Float, not fixed-point).

**#92 — `LibOpFtsoCurrentPricePair.run()`**: The `@return` said "normalized to 18 decimals" but the output is a packed Float ratio. Adds `@custom:error` documenting the divide-by-zero revert (unique to the pair op) when the quote price is zero, and corrects the `@return` to describe the base/quote Float output.

**#94 — `LibOpSFlrCurrentExchangeRate`**: Both `integrity()` and `run()` comments said "FLR to SFLR/sFLR" without stating which quantity is the numerator. Adds an explicit `@return` on `run()` documenting the value as `getSharesByPooledFlr(1e18) / 1e18` (sFLR-per-FLR) and clarifying that a value < 1 is expected after staking accrual.

Closes #92
Closes #93
Closes #94

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified output representation for FTSO price pair function as a float-encoded ratio
  * Clarified output representation for FTSO USD price function as a float value
  * Clarified sFLR exchange rate function output semantics and error propagation behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->