### PR TITLE
test: document overpayment surplus-stranded behavior in FtsoV2LTS

### DIFF
--- a/test/src/lib/lts/LibFtsoV2LTS.t.sol
+++ b/test/src/lib/lts/LibFtsoV2LTS.t.sol
@@ -76,5 +76,13 @@ contract LibFtsoV2LTSTest is Test {
         uint256 feedValue = feedConsumer.getFeedValue{value: alice.balance}(ETH_USD_FEED_ID, 3600);
         assertEq(feedValue, 2522.575e18);
         assertEq(alice.balance, 0);
+
+        // #56 — overpayment: surplus is stranded in the consumer (documents current behavior;
+        // replace with refund assertion when a refund mechanism is added).
+        vm.deal(alice, uint256(fee) + 1 ether);
+        uint256 overpaidValue = feedConsumer.getFeedValue{value: alice.balance}(ETH_USD_FEED_ID, 3600);
+        assertEq(overpaidValue, 2522.575e18);
+        assertEq(address(feedConsumer).balance, 1 ether);
+        assertEq(alice.balance, 0);
     }
 }


### PR DESCRIPTION
## Summary

- Extends `testFtsoV2LTSGetFeedPaid` to send `fee + 1 ether` and assert that the surplus `1 ether` is stranded in the `FeedConsumer` contract after the call
- Documents the current behavior (no refund) so a future fix has a failing assertion to satisfy
- Only `fee` is forwarded to the FTSO contract via `{value: fee}`; excess value remains in the consumer

Closes #56

## Test plan

- `forge test --match-test testFtsoV2LTSGetFeedPaid` passes (runs: 1, fork)

Co-Authored-By: Claude <noreply@anthropic.com>