### PR TITLE
refactor: centralize fork BLOCK_NUMBER pins in test/fork/ForkConstants.sol

### DIFF
--- a/test/fork/ForkConstants.sol
+++ b/test/fork/ForkConstants.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.19;
+
+/// @dev Canonical block number for most Flare fork tests.
+uint256 constant BLOCK_NUMBER = 31843105;
+
+/// @dev Canonical block number for flrETH fork tests (uses a later block where
+/// the flrETH contract is available).
+uint256 constant FLRETH_BLOCK_NUMBER = 37796420;

--- a/test/prod/FlareInterfacesProd.t.sol
+++ b/test/prod/FlareInterfacesProd.t.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "../fork/LibFork.sol";
-import {BLOCK_NUMBER} from "../src/lib/registry/LibFlareContractRegistry.t.sol";
+import {BLOCK_NUMBER} from "../fork/ForkConstants.sol";
 
 import {IFlareContractRegistry} from "../../src/vendor/flare-smart-contracts/userInterfaces/IFlareContractRegistry.sol";
 import {IFtsoRegistry} from "../../src/vendor/flare-smart-contracts/userInterfaces/IFtsoRegistry.sol";

--- a/test/src/concrete/FlareFtsoWords.ftsoCurrentPricePair.t.sol
+++ b/test/src/concrete/FlareFtsoWords.ftsoCurrentPricePair.t.sol
@@ -6,7 +6,7 @@ import {OpTest, StackItem} from "rainlang-0.1.2/src/../test/abstract/OpTest.sol"
 import {FlareFtsoWords} from "src/concrete/FlareFtsoWords.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {Strings} from "@openzeppelin-contracts-5.6.1/utils/Strings.sol";
-import {BLOCK_NUMBER} from "../lib/registry/LibFlareContractRegistry.t.sol";
+import {BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
 
 contract FlareFtsoWordsFtsoCurrentPricePairTest is OpTest {

--- a/test/src/concrete/FlareFtsoWords.ftsoCurrentPriceUsd.t.sol
+++ b/test/src/concrete/FlareFtsoWords.ftsoCurrentPriceUsd.t.sol
@@ -6,7 +6,7 @@ import {OpTest, StackItem} from "rainlang-0.1.2/src/../test/abstract/OpTest.sol"
 import {FlareFtsoWords} from "src/concrete/FlareFtsoWords.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {Strings} from "@openzeppelin-contracts-5.6.1/utils/Strings.sol";
-import {BLOCK_NUMBER} from "../lib/registry/LibFlareContractRegistry.t.sol";
+import {BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
 
 contract FlareFtsoWordsFtsoCurrentPriceUsdTest is OpTest {

--- a/test/src/concrete/FlareFtsoWords.sflrCurrentExchangeRate.t.sol
+++ b/test/src/concrete/FlareFtsoWords.sflrCurrentExchangeRate.t.sol
@@ -7,8 +7,7 @@ import {FlareFtsoWords} from "src/concrete/FlareFtsoWords.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {Strings} from "@openzeppelin-contracts-5.6.1/utils/Strings.sol";
 import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
-
-uint256 constant BLOCK_NUMBER = 31843105;
+import {BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 
 contract FlareSflrCurrentExchangeRateTest is OpTest {
     using Strings for address;

--- a/test/src/lib/flreth/LibDineroFlrEth.t.sol
+++ b/test/src/lib/flreth/LibDineroFlrEth.t.sol
@@ -5,12 +5,11 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {LibDineroFlrEth} from "src/lib/flreth/LibDineroFlrEth.sol";
-
-uint256 constant BLOCK_NUMBER = 37796420;
+import {FLRETH_BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 
 contract LibDineroFlrEthTest is Test {
     constructor() {
-        vm.createSelectFork(LibFork.rpcUrlFlare(vm), BLOCK_NUMBER);
+        vm.createSelectFork(LibFork.rpcUrlFlare(vm), FLRETH_BLOCK_NUMBER);
     }
 
     function testGetETHPerFLRETH18() external view {

--- a/test/src/lib/lts/LibFtsoV2LTS.t.sol
+++ b/test/src/lib/lts/LibFtsoV2LTS.t.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFtsoV2LTS, ETH_USD_FEED_ID} from "src/lib/lts/LibFtsoV2LTS.sol";
-import {BLOCK_NUMBER} from "../registry/LibFlareContractRegistry.t.sol";
+import {BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {LibFlareContractRegistry} from "src/lib/registry/LibFlareContractRegistry.sol";
 import {IFeeCalculator} from "../../../../src/vendor/flare-smart-contracts-v2/userInterfaces/IFeeCalculator.sol";

--- a/test/src/lib/op/LibOpFtsoCurrentPricePair.t.sol
+++ b/test/src/lib/op/LibOpFtsoCurrentPricePair.t.sol
@@ -5,7 +5,7 @@ pragma solidity =0.8.25;
 import {FtsoTest, OperandV2, StackItem, IFtso} from "../../../abstract/FtsoTest.sol";
 import {LibOpFtsoCurrentPricePair} from "src/lib/op/LibOpFtsoCurrentPricePair.sol";
 import {LibIntOrAString, IntOrAString} from "rain-intorastring-0.1.0/src/lib/LibIntOrAString.sol";
-import {BLOCK_NUMBER} from "../registry/LibFlareContractRegistry.t.sol";
+import {BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {InactiveFtso} from "src/err/ErrFtso.sol";
 import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";

--- a/test/src/lib/op/LibOpFtsoCurrentPriceUsd.t.sol
+++ b/test/src/lib/op/LibOpFtsoCurrentPriceUsd.t.sol
@@ -7,7 +7,7 @@ import {LibOpFtsoCurrentPriceUsd} from "src/lib/op/LibOpFtsoCurrentPriceUsd.sol"
 import {IFtso} from "src/lib/registry/LibFlareContractRegistry.sol";
 import {LibIntOrAString, IntOrAString} from "rain-intorastring-0.1.0/src/lib/LibIntOrAString.sol";
 import {LibFork} from "test/fork/LibFork.sol";
-import {BLOCK_NUMBER} from "../registry/LibFlareContractRegistry.t.sol";
+import {BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 import {InactiveFtso, PriceNotFinalized, StalePrice, DecimalsTooLarge} from "src/err/ErrFtso.sol";
 import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
 

--- a/test/src/lib/registry/LibFlareContractRegistry.t.sol
+++ b/test/src/lib/registry/LibFlareContractRegistry.t.sol
@@ -5,8 +5,7 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {LibFlareContractRegistry, IFtsoRegistry} from "src/lib/registry/LibFlareContractRegistry.sol";
-
-uint256 constant BLOCK_NUMBER = 31843105;
+import {BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 
 contract LibFlareContractRegistryTest is Test {
     constructor() {

--- a/test/src/lib/sflr/LibSceptreStakedFlare.t.sol
+++ b/test/src/lib/sflr/LibSceptreStakedFlare.t.sol
@@ -5,8 +5,7 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "test/fork/LibFork.sol";
 import {LibSceptreStakedFlare} from "src/lib/sflr/LibSceptreStakedFlare.sol";
-
-uint256 constant BLOCK_NUMBER = 31843105;
+import {BLOCK_NUMBER} from "test/fork/ForkConstants.sol";
 
 contract LibSceptreStakedFlareTest is Test {
     constructor() {


### PR DESCRIPTION
## Summary

- Creates `test/fork/ForkConstants.sol` with two canonical constants: `BLOCK_NUMBER = 31843105` (Flare fork block for most tests) and `FLRETH_BLOCK_NUMBER = 37796420` (flrETH-specific block)
- Removes all four independent re-declarations of `BLOCK_NUMBER` across `LibFlareContractRegistry.t.sol`, `LibSceptreStakedFlare.t.sol`, `FlareFtsoWords.sflrCurrentExchangeRate.t.sol`
- Updates `LibDineroFlrEth.t.sol` to use the named `FLRETH_BLOCK_NUMBER` constant (previously `BLOCK_NUMBER = 37796420` clashed with the other three)
- Updates all consumers (6 additional test files) to import from `ForkConstants.sol` instead of `LibFlareContractRegistry.t.sol`

Note: The hardcoded stale-price timestamp `1729795768` in `LibFtsoV2LTS.t.sol` is left as a known coupling; it is the ETH/USD feed timestamp at `BLOCK_NUMBER` and would need a fork read to derive dynamically (issue #109 documents this).

Note: Any branch that imports `BLOCK_NUMBER` from `LibFlareContractRegistry.t.sol` (e.g., PR #138) will need to update after this merges.

Closes #109

## Test plan

- `forge build` compiles with no errors

Co-Authored-By: Claude <noreply@anthropic.com>