### PR TITLE
fix: include meta/ in published soldeer package

### DIFF
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -27,4 +27,3 @@ CLAUDE.md
 /soldeer.lock
 /REUSE.toml
 /deployments
-/meta


### PR DESCRIPTION
\`/meta\` was listed in \`.soldeerignore\`, so the published soldeer package omitted
the \`meta/FlareFtsoWords.rain.meta\` file that both \`script/Deploy.sol\` and the
\`describedByMeta\` test read from disk via \`vm.readFileBinary\`. Any downstream
consumer vendoring rain-flare via soldeer would hit a missing-file revert on
deploy or test run.

Dropping the entry ships the canonical meta blob with the package, making
vendored deploy and test work without any extra setup.

Closes #107

Co-Authored-By: Claude <noreply@anthropic.com>