### PR TITLE
test: pin registry name literals with an offline pure assertion

### DIFF
--- a/test/src/lib/registry/LibFlareContractRegistry.t.sol
+++ b/test/src/lib/registry/LibFlareContractRegistry.t.sol
@@ -4,13 +4,25 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "test/fork/LibFork.sol";
-import {LibFlareContractRegistry, IFtsoRegistry} from "src/lib/registry/LibFlareContractRegistry.sol";
+import {
+    LibFlareContractRegistry,
+    IFtsoRegistry,
+    FTSO_REGISTRY_NAME,
+    FTSO_V2_LTS_NAME,
+    FEE_CALCULATOR_NAME
+} from "src/lib/registry/LibFlareContractRegistry.sol";
 
 uint256 constant BLOCK_NUMBER = 31843105;
 
 contract LibFlareContractRegistryTest is Test {
     constructor() {
         vm.createSelectFork(LibFork.rpcUrlFlare(vm), BLOCK_NUMBER);
+    }
+
+    function testRegistryNameLiterals() external pure {
+        assertEq(FTSO_REGISTRY_NAME, "FtsoRegistry");
+        assertEq(FTSO_V2_LTS_NAME, "FtsoV2");
+        assertEq(FEE_CALCULATOR_NAME, "FeeCalculator");
     }
 
     function testGetFtsoRegistry() external view {


### PR DESCRIPTION
The three registry name constants (`FTSO_REGISTRY_NAME`, `FTSO_V2_LTS_NAME`,
`FEE_CALCULATOR_NAME`) are the exact strings hashed by the Flare contract
registry to resolve every downstream contract.  The only existing test imports
the constants and checks they resolve to a non-zero address on a live fork —
any typo flows through identically into both sides and a wrong-but-non-zero
address wouldn't be caught.

The new `testRegistryNameLiterals()` is a pure test that hardcodes the expected
byte literals independently of the constants, so any rename of a registry key
fails in non-fork CI before it can silently corrupt price reads.

Closes #108

Co-Authored-By: Claude <noreply@anthropic.com>