### PR TITLE
fix: treat priceTimestamp+timeout overflow as stale, not a panic

### DIFF
--- a/src/generated/FlareFtsoWords.pointers.sol
+++ b/src/generated/FlareFtsoWords.pointers.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.8.25;
 // file needs the contract to exist so that it can be compiled.
 
 /// @dev Hash of the known bytecode.
-bytes32 constant BYTECODE_HASH = bytes32(0x96e4ec5ff213f69e32f76c5ce42fb5ae8a42af3ad080341ce1d1b74a0061723d);
+bytes32 constant BYTECODE_HASH = bytes32(0x1009eb4c3a377a298162ec21d6f2d479377f243349cca5eea4314474a788eef9);
 
 /// @dev The hash of the meta that describes the contract.
 bytes32 constant DESCRIBED_BY_META_HASH = bytes32(0x8717d07737e3cedcdddea6cd3337ae762d7089918bf8d818fb0afc5b63e3985a);

--- a/src/lib/price/LibFtsoCurrentPriceUsd.sol
+++ b/src/lib/price/LibFtsoCurrentPriceUsd.sol
@@ -45,10 +45,15 @@ library LibFtsoCurrentPriceUsd {
             revert InconsistentFtso();
         }
 
-        // Handle stale prices.
+        // Handle stale prices. Use unchecked to avoid Panic(0x11) from a
+        // misbehaving FTSO that reports a near-uint256-max timestamp; an
+        // overflowing deadline is treated as stale.
         //slither-disable-next-line timestamp
-        if (block.timestamp > priceTimestamp + timeout) {
-            revert StalePrice(priceTimestamp, timeout);
+        unchecked {
+            uint256 deadline = priceTimestamp + timeout;
+            if (deadline < priceTimestamp || block.timestamp > deadline) {
+                revert StalePrice(priceTimestamp, timeout);
+            }
         }
 
         return (price, decimals);

--- a/src/lib/price/LibFtsoCurrentPriceUsd.sol
+++ b/src/lib/price/LibFtsoCurrentPriceUsd.sol
@@ -48,13 +48,14 @@ library LibFtsoCurrentPriceUsd {
         // Handle stale prices. Use unchecked to avoid Panic(0x11) from a
         // misbehaving FTSO that reports a near-uint256-max timestamp; an
         // overflowing deadline is treated as stale.
-        //slither-disable-next-line timestamp
+        //slither-disable-start timestamp
         unchecked {
             uint256 deadline = priceTimestamp + timeout;
             if (deadline < priceTimestamp || block.timestamp > deadline) {
                 revert StalePrice(priceTimestamp, timeout);
             }
         }
+        //slither-disable-end
 
         return (price, decimals);
     }

--- a/test/src/lib/op/LibOpFtsoCurrentPriceUsd.t.sol
+++ b/test/src/lib/op/LibOpFtsoCurrentPriceUsd.t.sol
@@ -161,6 +161,41 @@ contract LibOpFtsoCurrentPriceUsdTest is FtsoTest {
         this.externalRun(operand, inputs);
     }
 
+    /// When priceTimestamp + timeout overflows uint256, the staleness check must
+    /// revert with StalePrice rather than panic with Panic(0x11).
+    function testRunStaleOverflow(
+        OperandV2 operand,
+        string memory symbol,
+        uint256 timeout,
+        uint256 currentTime,
+        PriceDetails memory priceDetails,
+        CurrentPrice memory currentPrice
+    ) external {
+        vm.assume(bytes(symbol).length <= 31);
+        uint256 intSymbol = IntOrAString.unwrap(LibIntOrAString.fromStringV3(symbol));
+
+        timeout = bound(timeout, 1, uint256(int256(type(int224).max)));
+        // Force priceTimestamp + timeout to overflow.
+        currentPrice.timestamp = bound(currentPrice.timestamp, type(uint256).max - timeout + 1, type(uint256).max);
+        currentTime = bound(currentTime, 0, type(uint256).max);
+        vm.warp(currentTime);
+
+        conformPriceDetails(priceDetails, currentPrice);
+        finalizePrice(priceDetails);
+
+        mockRegistry();
+        mockFtsoRegistry(FTSO, symbol);
+        activateFtso();
+        mockPriceDetails(priceDetails);
+        mockPrice(FTSO, currentPrice);
+
+        StackItem[] memory inputs = new StackItem[](2);
+        inputs[0] = StackItem.wrap(bytes32(intSymbol));
+        inputs[1] = StackItem.wrap(Float.unwrap(LibDecimalFloat.fromFixedDecimalLosslessPacked(timeout, 0)));
+        vm.expectRevert(abi.encodeWithSelector(StalePrice.selector, currentPrice.timestamp, timeout));
+        this.externalRun(operand, inputs);
+    }
+
     /// Anything other than WEIGHTED_MEDIAN or TRUSTED_ADDRESSES should revert
     /// as it means the price is not final.
     function testRunFtsoNotFinal(


### PR DESCRIPTION
`priceTimestamp + timeout` in `LibFtsoCurrentPriceUsd.ftsoCurrentPriceUsd`
uses checked arithmetic (Solidity 0.8 default). A misbehaving or compromised
FTSO that reports a near-`type(uint256).max` timestamp causes `Panic(0x11)`
instead of the intended `StalePrice` domain error, making the failure harder to
diagnose.

The fix uses `unchecked` arithmetic and checks `deadline < priceTimestamp`
as the overflow sentinel, converting the overflow into a clean `StalePrice`
revert that callers already handle.

A new `testRunStaleOverflow` fuzz test covers the overflow boundary
(`priceTimestamp > type(uint256).max - timeout`) and verifies `StalePrice`
is emitted rather than a panic.

Closes #105

Co-Authored-By: Claude <noreply@anthropic.com>