### PR TITLE
docs: clarify rounding for pair price derivation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Regardless, it is NOT recommended that this word be used for high precision
 calculations, as derived prices can drift from reality simply due to differences
 in the reporting times.
 
+The pair derivation divides two decimal floating-point prices using
+`LibDecimalFloat.div`. When the quotient is not exact, it rounds toward zero
+(i.e. slightly understates the derived price for positive prices). This is
+distinct from the single-FTSO decimal rescaling described in the Decimals
+section below, which also rounds down.
+
 ### Timeouts
 
 The rainlang author must provide a timeout which is used to guarantee that prices
@@ -77,8 +83,8 @@ The rescaling is generally lossless except in two edge cases:
 - When scaling numbers _down_ (i.e. ftso decimals is more than 18) there can be
   loss of precision for the significant figures beyond 18 decimals
 
-In the latter case of precision loss, rounding is always down as per EVM default
-behaviour.
+In the latter case of precision loss, the single-FTSO decimal rescale rounds
+down as per EVM default behaviour.
 
 ## Dev stuff
 


### PR DESCRIPTION
The README stated "rounding is always down as per EVM default behaviour" in the
Decimals section without scoping it to the single-FTSO decimal rescale only.
A reader could assume this blanket rule covers `ftso-current-price-pair`'s
derived-price division too, but that path uses `LibDecimalFloat.div` (decimal
floating-point, distinct from integer rescaling).

Changes:
- Scope the "rounds down" statement to "single-FTSO decimal rescale" explicitly.
- Add a sentence to the `ftso-current-price-pair` section stating that
  `LibDecimalFloat.div` rounds toward zero (understates the derived price when
  not exact) and is separate from the decimal rescaling step.

Closes #70

Co-Authored-By: Claude <noreply@anthropic.com>