### PR TITLE
docs: scope staleness/finalization NatSpec to FTSO words only

### DIFF
--- a/src/abstract/FlareFtsoExtern.sol
+++ b/src/abstract/FlareFtsoExtern.sol
@@ -26,8 +26,11 @@ uint256 constant OPCODE_FUNCTION_POINTERS_LENGTH = 3;
 ///
 /// Handles things such as:
 /// - Looking up the correct FTSO contract for a given symbol from registries.
-/// - Checking finalization status of prices and rejecting if not finalized.
-/// - Checking the timestamp of prices and rejecting if too old.
+/// - Checking finalization status of FTSO prices and rejecting if not finalized
+///   (applies to ftso-current-price-usd and ftso-current-price-pair only).
+/// - Checking the timestamp of FTSO prices and rejecting if too old (applies to
+///   ftso-current-price-usd and ftso-current-price-pair only; the sFLR exchange
+///   rate is an on-chain protocol value with no meaningful staleness concept).
 /// - Normalizing prices to 18 decimal fixed point.
 /// - Aggregate logic for multiple FTSOs such as deriving pair prices from two
 ///   symbols given a shared USD denominator.


### PR DESCRIPTION
\`FlareFtsoExtern\` NatSpec stated it checks "finalization status of prices" and
"timestamp of prices" without qualification. The sFLR exchange-rate word reads
a monotonic on-chain staking contract value — there is no finalized round, no
push oracle, no timestamp concept — so those checks do not apply to it.

The two bullet points are scoped to \`ftso-current-price-usd\` and
\`ftso-current-price-pair\` explicitly, with a note explaining why sFLR is
excluded.

Closes #44

Co-Authored-By: Claude <noreply@anthropic.com>