### PR TITLE
fix(deploy): assert meta file matches compiled DESCRIBED_BY_META_HASH

### DIFF
--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -15,6 +15,10 @@ contract Deploy is Script {
 
         vm.startBroadcast(deployerPrivateKey);
         FlareFtsoWords subParser = new FlareFtsoWords();
+        require(
+            keccak256(subParserDescribedByMeta) == subParser.describedByMetaV1(),
+            "meta file does not match compiled DESCRIBED_BY_META_HASH"
+        );
         LibDescribedByMeta.emitForDescribedAddress(metaboard, subParser, subParserDescribedByMeta);
 
         vm.stopBroadcast();


### PR DESCRIPTION
## Summary

Deploy.sol reads meta/FlareFtsoWords.rain.meta from disk and emits it on-chain, but never verified that the file content matches the DESCRIBED_BY_META_HASH compiled into FlareFtsoWords. A stale or mismatched file would silently publish incorrect metadata.

Adds a require between deploying the contract and emitting the meta, running inside vm.startBroadcast so it reverts the deploy transaction before any on-chain state is written if the hashes diverge.

Closes #49

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deployment validation to ensure metadata integrity and prevent contracts with mismatched metadata from being deployed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->