### PR TITLE
fix: collapse PARSE_META_BUILD_DEPTH to single canonical source in generated pointers

### DIFF
--- a/script/BuildPointers.sol
+++ b/script/BuildPointers.sol
@@ -7,7 +7,7 @@ import {Script} from "forge-std-1.16.1/src/Script.sol";
 import {FlareFtsoWords} from "src/concrete/FlareFtsoWords.sol";
 import {LibCodeGen} from "rain-sol-codegen-0.1.0/src/lib/LibCodeGen.sol";
 import {LibFs} from "rain-sol-codegen-0.1.0/src/lib/LibFs.sol";
-import {PARSE_META_BUILD_DEPTH} from "src/abstract/FlareFtsoSubParser.sol";
+import {PARSE_META_BUILD_DEPTH} from "src/generated/FlareFtsoWords.pointers.sol";
 import {LibFlareFtsoSubParser} from "src/lib/parse/LibFlareFtsoSubParser.sol";
 import {LibGenParseMeta} from "rain-interpreter-interface-0.1.0/src/lib/codegen/LibGenParseMeta.sol";
 

--- a/src/abstract/FlareFtsoSubParser.sol
+++ b/src/abstract/FlareFtsoSubParser.sol
@@ -28,10 +28,9 @@ import {
 import {
     OPERAND_HANDLER_FUNCTION_POINTERS as SUB_PARSER_OPERAND_HANDLERS,
     SUB_PARSER_WORD_PARSERS,
-    PARSE_META as SUB_PARSER_PARSE_META
+    PARSE_META as SUB_PARSER_PARSE_META,
+    PARSE_META_BUILD_DEPTH
 } from "../generated/FlareFtsoWords.pointers.sol";
-
-uint8 constant PARSE_META_BUILD_DEPTH = 1;
 
 /// @title FlareFtsoSubParser
 /// Implements the sub parser half of FlareFtsoWords. Responsible for parsing

--- a/src/concrete/FlareFtsoWords.sol
+++ b/src/concrete/FlareFtsoWords.sol
@@ -23,6 +23,9 @@ import {
 
     //forge-lint: disable-next-line(unused-import)
     SUB_PARSER_PARSE_META,
+
+    //forge-lint: disable-next-line(unused-import)
+    PARSE_META_BUILD_DEPTH,
     BaseRainlangSubParser,
 
     //forge-lint: disable-next-line(unused-import)

--- a/test/src/concrete/FlareFtsoWords.pointers.t.sol
+++ b/test/src/concrete/FlareFtsoWords.pointers.t.sol
@@ -10,6 +10,7 @@ import {
     OPCODE_FUNCTION_POINTERS,
     SUB_PARSER_WORD_PARSERS,
     SUB_PARSER_PARSE_META,
+    PARSE_META_BUILD_DEPTH,
     AuthoringMetaV2
 } from "src/concrete/FlareFtsoWords.sol";
 import {LibGenParseMeta} from "rain-interpreter-interface-0.1.0/src/lib/codegen/LibGenParseMeta.sol";
@@ -39,7 +40,8 @@ contract FlareFtsoWordsPointersTest is Test {
     function testSubParserParseMeta() external pure {
         bytes memory authoringMetaBytes = LibFlareFtsoSubParser.authoringMetaV2();
         AuthoringMetaV2[] memory authoringMeta = abi.decode(authoringMetaBytes, (AuthoringMetaV2[]));
-        bytes memory expected = LibGenParseMeta.buildParseMetaV2(authoringMeta, 2);
+        bytes memory expected = LibGenParseMeta.buildParseMetaV2(authoringMeta, PARSE_META_BUILD_DEPTH);
         assertEq(SUB_PARSER_PARSE_META, expected);
+        assertEq(uint8(SUB_PARSER_PARSE_META[0]), PARSE_META_BUILD_DEPTH, "parse meta depth byte");
     }
 }


### PR DESCRIPTION
## Summary

The parse-meta build depth was declared in three places that were not enforced to agree:

- `src/generated/FlareFtsoWords.pointers.sol:39` — `PARSE_META_BUILD_DEPTH = 1` (generated canonical source)
- `src/abstract/FlareFtsoSubParser.sol:34` — redundant `PARSE_META_BUILD_DEPTH = 1`
- `test/src/concrete/FlareFtsoWords.pointers.t.sol:42` — hardcoded literal `2` (coincidentally identical result for the 3-word set, so the depth was not being validated at all)

This PR collapses them to the single canonical source:

1. **`FlareFtsoSubParser.sol`**: remove the local constant declaration; import `PARSE_META_BUILD_DEPTH` from the generated pointers file alongside the other generated constants.
2. **`BuildPointers.sol`**: update import to pull `PARSE_META_BUILD_DEPTH` from the generated file directly (the file it generates) instead of via `FlareFtsoSubParser`.
3. **`FlareFtsoWords.sol`**: re-export `PARSE_META_BUILD_DEPTH` so it is reachable from tests that import via the concrete contract.
4. **`FlareFtsoWords.pointers.t.sol`**: import and use `PARSE_META_BUILD_DEPTH` instead of the literal `2`; add `assertEq(uint8(SUB_PARSER_PARSE_META[0]), PARSE_META_BUILD_DEPTH)` to pin the runtime depth byte to the constant.

Closes #50

Co-Authored-By: Claude <noreply@anthropic.com>