### PR TITLE
fix: add BuildPointers.sol to build prelude so pointers drift fails copy-artifacts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
                 -l none \
                 -o meta/FlareFtsoWords.rain.meta \
                 ;
+              forge script --silent ./script/BuildPointers.sol;
             '';
             additionalBuildInputs = rainix.sol-build-inputs.${system} ++ [ rain.defaultPackage.${system} ];
           };

--- a/script/build.sh
+++ b/script/build.sh
@@ -9,4 +9,5 @@ nix develop -c bash -euxo pipefail -c '
   mkdir -p meta
   forge script --silent ./script/BuildAuthoringMeta.sol
   rain meta build -i <(cat ./meta/FlareFtsoSubParserAuthoringMeta.rain.meta) -m authoring-meta-v2 -t cbor -e deflate -l none -o meta/FlareFtsoWords.rain.meta
+  forge script --silent ./script/BuildPointers.sol
 '


### PR DESCRIPTION
Closes #48

`script/build.sh` and `flake.nix` rain-flare-prelude regenerated the authoring-meta artifacts but never invoked `BuildPointers.sol`, so `src/generated/FlareFtsoWords.pointers.sol` (which contains `BYTECODE_HASH`, `DESCRIBED_BY_META_HASH`, `PARSE_META_BUILD_DEPTH`, etc.) could silently go stale. The copy-artifacts CI diff never caught this because it only diffed what the prelude regenerated.

Adds `forge script --silent ./script/BuildPointers.sol` to both the nix prelude body and `build.sh` inline block, so every CI push regenerates the pointers file and any drift causes copy-artifacts to go red.

Note: `foundry.toml` already has `fs_permissions` read-write on `src/generated`, so no further config is needed.

Co-Authored-By: Claude <noreply@anthropic.com>