### PR TITLE
ci: pin reusable workflow refs to rainix SHA 6b43e604

### DIFF
--- a/.github/workflows/git-clean.yaml
+++ b/.github/workflows/git-clean.yaml
@@ -2,5 +2,5 @@ name: Git is clean
 on: [push]
 jobs:
   copy-artifacts:
-    uses: rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@main
+    uses: rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@6b43e604e1b6ce3c00ece4ae159bb5d1457548b5
     secrets: inherit

--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -10,7 +10,7 @@ on:
           - flare-ftso-words
 jobs:
   deploy:
-    uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@main
+    uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@6b43e604e1b6ce3c00ece4ae159bb5d1457548b5
     with:
       suite: ${{ inputs.suite }}
     secrets: inherit

--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   release:
-    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
+    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@6b43e604e1b6ce3c00ece4ae159bb5d1457548b5
     with:
       soldeer-package: rain-flare
     secrets: inherit

--- a/.github/workflows/rainix-sol.yaml
+++ b/.github/workflows/rainix-sol.yaml
@@ -2,5 +2,5 @@ name: rainix-sol
 on: [push]
 jobs:
   rainix-sol:
-    uses: rainlanguage/rainix/.github/workflows/rainix-sol.yaml@main
+    uses: rainlanguage/rainix/.github/workflows/rainix-sol.yaml@6b43e604e1b6ce3c00ece4ae159bb5d1457548b5
     secrets: inherit


### PR DESCRIPTION
Closes #52

## What

All four GitHub Actions workflows in rain.flare referenced rainix reusable workflows with \`@main\`, making the CI non-reproducible — any rainix change takes effect silently on the next push with no audit trail.

Pins all four \`uses:\` references to the current rainix main SHA \`6b43e604e1b6ce3c00ece4ae159bb5d1457548b5\`:
- \`rainix-sol.yaml\` → \`rainix-sol.yaml@6b43e604\`
- \`git-clean.yaml\` → \`rainix-copy-artifacts.yaml@6b43e604\`
- \`manual-sol-artifacts.yaml\` → \`rainix-manual-sol-artifacts.yaml@6b43e604\`
- \`package-release.yaml\` → \`rainix-autopublish.yaml@6b43e604\`

Future rainix bumps require an explicit PR to update the SHA, creating a clear audit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>