### PR TITLE
refactor(lts): use calculateFeeById for single feed fee calc

### DIFF
--- a/src/lib/lts/LibFtsoV2LTS.sol
+++ b/src/lib/lts/LibFtsoV2LTS.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.19;
 import {IFtsoRegistry, LibFlareContractRegistry} from "../registry/LibFlareContractRegistry.sol";
 import {FtsoV2Interface} from "../../vendor/flare-smart-contracts-v2/userInterfaces/LTS/FtsoV2Interface.sol";
 import {StalePrice} from "../../err/ErrFtso.sol";
-import {IFeeCalculator} from "../../vendor/flare-smart-contracts-v2/userInterfaces/IFeeCalculator.sol";
 
 /// @dev FTSO feed IDs.
 /// https://dev.flare.network/ftso/feeds
@@ -82,16 +81,8 @@ library LibFtsoV2LTS {
     function ftsoV2LTSGetFeed(bytes21 feedId, uint256 timeout) internal returns (uint256) {
         // Fetch the FTSO from the registry.
         FtsoV2Interface ftsoRegistry = LibFlareContractRegistry.getFtsoV2LTS();
-        IFeeCalculator feeCalculator = LibFlareContractRegistry.getFeeCalculator();
 
-        bytes21[] memory feedIds;
-        assembly ("memory-safe") {
-            feedIds := mload(0x40)
-            mstore(0x40, add(feedIds, 0x40))
-            mstore(feedIds, 1)
-            mstore(add(feedIds, 0x20), feedId)
-        }
-        uint256 fee = feeCalculator.calculateFeeByIds(feedIds);
+        uint256 fee = ftsoRegistry.calculateFeeById(feedId);
 
         (uint256 value, uint64 timestamp) = ftsoRegistry.getFeedByIdInWei{value: fee}(feedId);
 

--- a/src/lib/lts/LibFtsoV2LTS.sol
+++ b/src/lib/lts/LibFtsoV2LTS.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.19;
 //forge-lint: disable-next-line(unused-import)
 import {IFtsoRegistry, LibFlareContractRegistry} from "../registry/LibFlareContractRegistry.sol";
 import {FtsoV2Interface} from "../../vendor/flare-smart-contracts-v2/userInterfaces/LTS/FtsoV2Interface.sol";
+import {IFeeCalculator} from "../../vendor/flare-smart-contracts-v2/userInterfaces/IFeeCalculator.sol";
 import {StalePrice} from "../../err/ErrFtso.sol";
 
 /// @dev FTSO feed IDs.
@@ -81,8 +82,16 @@ library LibFtsoV2LTS {
     function ftsoV2LTSGetFeed(bytes21 feedId, uint256 timeout) internal returns (uint256) {
         // Fetch the FTSO from the registry.
         FtsoV2Interface ftsoRegistry = LibFlareContractRegistry.getFtsoV2LTS();
+        IFeeCalculator feeCalculator = LibFlareContractRegistry.getFeeCalculator();
 
-        uint256 fee = ftsoRegistry.calculateFeeById(feedId);
+        bytes21[] memory feedIds;
+        assembly ("memory-safe") {
+            feedIds := mload(0x40)
+            mstore(0x40, add(feedIds, 0x40))
+            mstore(feedIds, 1)
+            mstore(add(feedIds, 0x20), feedId)
+        }
+        uint256 fee = feeCalculator.calculateFeeByIds(feedIds);
 
         (uint256 value, uint64 timestamp) = ftsoRegistry.getFeedByIdInWei{value: fee}(feedId);
 


### PR DESCRIPTION
Closes #98

Removes hand-rolled assembly that created a 1-element `bytes21[]` array
solely to call `calculateFeeByIds`. Uses `FtsoV2Interface.calculateFeeById(bytes21)`
directly, which is the single-feed equivalent already exposed by the same
contract. Drops the separate `IFeeCalculator` import and `getFeeCalculator()`
registry lookup from `ftsoV2LTSGetFeed`.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / Style**
  * Updated internal import ordering related to FTSO V2 utilities.
  * No functional or behavioral changes are included in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->