### PR TITLE
docs(natspec): fix copy-pasted sFlrExchangeRate comment and add @return to build* fns

### DIFF
--- a/src/abstract/FlareFtsoExtern.sol
+++ b/src/abstract/FlareFtsoExtern.sol
@@ -49,6 +49,8 @@ abstract contract FlareFtsoExtern is BaseRainlangExtern {
     /// Create a 16-bit pointer array for the opcode function pointers. This is
     /// relatively gas inefficent so it is only called during tests to cross
     /// reference against the constant values that are used at runtime.
+    /// @return A packed array of 16-bit function pointers, one per opcode, ordered by
+    /// OPCODE_* index, to cross-reference against OPCODE_FUNCTION_POINTERS at runtime.
     function buildOpcodeFunctionPointers() external pure returns (bytes memory) {
         function(OperandV2, StackItem[] memory) internal view returns (StackItem[] memory)[] memory fs = new function(OperandV2, StackItem[] memory)
         internal
@@ -67,6 +69,8 @@ abstract contract FlareFtsoExtern is BaseRainlangExtern {
     /// Create a 16-bit pointer array for the integrity function pointers. This
     /// is relatively gas inefficent so it is only called during tests to cross
     /// reference against the constant values that are used at runtime.
+    /// @return A packed array of 16-bit function pointers, one per opcode, ordered by
+    /// OPCODE_* index, to cross-reference against INTEGRITY_FUNCTION_POINTERS at runtime.
     function buildIntegrityFunctionPointers() external pure returns (bytes memory) {
         function(OperandV2, uint256, uint256) internal pure returns (uint256, uint256)[] memory fs = new function(OperandV2, uint256, uint256)
         internal

--- a/src/abstract/FlareFtsoSubParser.sol
+++ b/src/abstract/FlareFtsoSubParser.sol
@@ -128,7 +128,7 @@ abstract contract FlareFtsoSubParser is BaseRainlangSubParser {
     }
 
     /// Thin wrapper around LibSubParse.subParserExtern that provides the extern
-    /// address and index of the current pair price opcode index in the extern.
+    /// address and index of the sFLR current exchange rate opcode index in the extern.
     //slither-disable-next-line dead-code
     function sFlrCurrentExchangeRateSubParser(uint256 constantsHeight, uint256 ioByte, OperandV2 operand)
         internal


### PR DESCRIPTION
## Summary

### Issue #87 — copy-pasted NatSpec describes wrong opcode for `sFlrCurrentExchangeRateSubParser`
The doc comment on `sFlrCurrentExchangeRateSubParser` read "address and index of the **current pair price** opcode index in the extern" — a verbatim copy from `ftsoCurrentPricePairSubParser`. The function actually wires `OPCODE_SFLR_CURRENT_EXCHANGE_RATE`, not the pair-price opcode. Fixed to say "sFLR current exchange rate opcode index".

### Issue #86 — `buildOpcodeFunctionPointers` / `buildIntegrityFunctionPointers` missing `@return` NatSpec
Both external functions in `FlareFtsoExtern.sol` had no `@return` tag. Added a `@return` note explaining the result is a packed array of 16-bit function pointers, ordered by `OPCODE_*` index, for cross-referencing against `OPCODE_FUNCTION_POINTERS` / `INTEGRITY_FUNCTION_POINTERS` at runtime.

Closes #86
Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>