### PR TITLE
test(registry): add offline pure test for registry name literal strings

### DIFF
--- a/test/src/lib/registry/LibFlareContractRegistry.t.sol
+++ b/test/src/lib/registry/LibFlareContractRegistry.t.sol
@@ -4,7 +4,13 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibFork} from "test/fork/LibFork.sol";
-import {LibFlareContractRegistry, IFtsoRegistry} from "src/lib/registry/LibFlareContractRegistry.sol";
+import {
+    LibFlareContractRegistry,
+    IFtsoRegistry,
+    FTSO_REGISTRY_NAME,
+    FTSO_V2_LTS_NAME,
+    FEE_CALCULATOR_NAME
+} from "src/lib/registry/LibFlareContractRegistry.sol";
 
 uint256 constant BLOCK_NUMBER = 31843105;
 
@@ -16,5 +22,11 @@ contract LibFlareContractRegistryTest is Test {
     function testGetFtsoRegistry() external view {
         IFtsoRegistry ftsoRegistry = LibFlareContractRegistry.getFtsoRegistry();
         assertEq(address(ftsoRegistry), address(0x13DC2b5053857AE17a4f95aFF55530b267F3E040));
+    }
+
+    function testRegistryNameLiterals() external pure {
+        assertEq(FTSO_REGISTRY_NAME, "FtsoRegistry");
+        assertEq(FTSO_V2_LTS_NAME, "FtsoV2");
+        assertEq(FEE_CALCULATOR_NAME, "FeeCalculator");
     }
 }


### PR DESCRIPTION
## Summary

The Flare registry lookup name strings (`FtsoRegistry`, `FtsoV2`, `FeeCalculator`) are used to look up contracts from the Flare contract registry. A silent typo or rename would flow through both the production call and the fork test identically. This adds a pure (no-fork) assertion that pins the literal bytes independently of the constants, so any accidental rename fails without needing a live RPC.

## Test plan

- [ ] `testRegistryNameLiterals` passes (pure, no fork needed)
- [ ] CI rainix-sol-test passes

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)