### PR TITLE
fix(soldeer): include meta/ in published soldeer package

### DIFF
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -27,4 +27,3 @@ CLAUDE.md
 /soldeer.lock
 /REUSE.toml
 /deployments
-/meta


### PR DESCRIPTION
## Summary
- Removes `/meta` from `.soldeerignore` so `meta/FlareFtsoWords.rain.meta` is included in published soldeer packages
- Fixes the scenario where a downstream repo consuming rain-flare via soldeer tries to run `Deploy.sol` or `testFlareFtsoWordsDescribedByMeta` and gets a missing-file revert

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)