### PR TITLE
fix(staleness): guard priceTimestamp+timeout overflow; treat as stale

### DIFF
--- a/src/generated/FlareFtsoWords.pointers.sol
+++ b/src/generated/FlareFtsoWords.pointers.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.8.25;
 // file needs the contract to exist so that it can be compiled.
 
 /// @dev Hash of the known bytecode.
-bytes32 constant BYTECODE_HASH = bytes32(0x96e4ec5ff213f69e32f76c5ce42fb5ae8a42af3ad080341ce1d1b74a0061723d);
+bytes32 constant BYTECODE_HASH = bytes32(0x1009eb4c3a377a298162ec21d6f2d479377f243349cca5eea4314474a788eef9);
 
 /// @dev The hash of the meta that describes the contract.
 bytes32 constant DESCRIBED_BY_META_HASH = bytes32(0x8717d07737e3cedcdddea6cd3337ae762d7089918bf8d818fb0afc5b63e3985a);

--- a/src/lib/price/LibFtsoCurrentPriceUsd.sol
+++ b/src/lib/price/LibFtsoCurrentPriceUsd.sol
@@ -48,9 +48,9 @@ library LibFtsoCurrentPriceUsd {
         // Handle stale prices. Use unchecked addition so a near-max
         // priceTimestamp doesn't panic; overflow wraps the deadline below
         // priceTimestamp, which we treat as stale.
-        //slither-disable-next-line timestamp
         unchecked {
             uint256 deadline = priceTimestamp + timeout;
+            //slither-disable-next-line timestamp
             if (deadline < priceTimestamp || block.timestamp > deadline) {
                 revert StalePrice(priceTimestamp, timeout);
             }

--- a/src/lib/price/LibFtsoCurrentPriceUsd.sol
+++ b/src/lib/price/LibFtsoCurrentPriceUsd.sol
@@ -45,10 +45,15 @@ library LibFtsoCurrentPriceUsd {
             revert InconsistentFtso();
         }
 
-        // Handle stale prices.
+        // Handle stale prices. Use unchecked addition so a near-max
+        // priceTimestamp doesn't panic; overflow wraps the deadline below
+        // priceTimestamp, which we treat as stale.
         //slither-disable-next-line timestamp
-        if (block.timestamp > priceTimestamp + timeout) {
-            revert StalePrice(priceTimestamp, timeout);
+        unchecked {
+            uint256 deadline = priceTimestamp + timeout;
+            if (deadline < priceTimestamp || block.timestamp > deadline) {
+                revert StalePrice(priceTimestamp, timeout);
+            }
         }
 
         return (price, decimals);

--- a/test/src/lib/op/LibOpFtsoCurrentPriceUsd.t.sol
+++ b/test/src/lib/op/LibOpFtsoCurrentPriceUsd.t.sol
@@ -417,4 +417,35 @@ contract LibOpFtsoCurrentPriceUsdTest is FtsoTest {
             Float.unwrap(LibDecimalFloat.packLossless(int256(currentPrice.price), -int256(currentPrice.decimals)))
         );
     }
+
+    function testRunStaleTimestampOverflow(
+        OperandV2 operand,
+        string memory symbol,
+        uint256 timeout,
+        PriceDetails memory priceDetails,
+        CurrentPrice memory currentPrice
+    ) external {
+        vm.assume(bytes(symbol).length <= 31);
+        timeout = bound(timeout, 1, uint256(int256(type(int224).max)));
+        currentPrice.price = bound(currentPrice.price, 0, uint256(int256(type(int224).max)));
+        currentPrice.decimals = bound(currentPrice.decimals, 0, type(uint8).max);
+        // Bound priceTimestamp so that priceTimestamp + timeout overflows uint256.
+        currentPrice.timestamp = bound(currentPrice.timestamp, type(uint256).max - timeout + 1, type(uint256).max);
+        uint256 intSymbol = IntOrAString.unwrap(LibIntOrAString.fromStringV3(symbol));
+
+        conformPriceDetails(priceDetails, currentPrice);
+        finalizePrice(priceDetails);
+
+        mockRegistry();
+        mockFtsoRegistry(FTSO, symbol);
+        activateFtso();
+        mockPriceDetails(priceDetails);
+        mockPrice(FTSO, currentPrice);
+
+        vm.expectRevert(abi.encodeWithSelector(StalePrice.selector, currentPrice.timestamp, timeout));
+        StackItem[] memory inputs = new StackItem[](2);
+        inputs[0] = StackItem.wrap(bytes32(intSymbol));
+        inputs[1] = StackItem.wrap(Float.unwrap(LibDecimalFloat.fromFixedDecimalLosslessPacked(timeout, 0)));
+        this.externalRun(operand, inputs);
+    }
 }


### PR DESCRIPTION
## Summary
- `LibFtsoCurrentPriceUsd.ftsoCurrentPriceUsd`: wrap the `priceTimestamp + timeout` addition in `unchecked` with an overflow guard — if the sum wraps below `priceTimestamp`, treat it as stale instead of panicking with `Panic(0x11)`.
- `testRunStaleTimestampOverflow`: fuzz test covering the new path, bounding `priceTimestamp` so `priceTimestamp + timeout` always overflows and asserting `StalePrice` (not a panic).

## Test plan
- [ ] `testRunStaleTimestampOverflow` passes (was previously impossible to reach the `StalePrice` path because checked arithmetic would panic first).
- [ ] Existing `testRunStale` and `testRunStaleBoundaryNotStale` still pass.
- [ ] CI green.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)