### PR TITLE
fix(test): assert empty revert bytes for OutOfFunds in testFtsoV2LTSGetFeedPaid

### DIFF
--- a/test/src/lib/lts/LibFtsoV2LTS.t.sol
+++ b/test/src/lib/lts/LibFtsoV2LTS.t.sol
@@ -65,10 +65,11 @@ contract LibFtsoV2LTSTest is Test {
         assertEq(alice.balance, fee - 1);
 
         vm.startPrank(alice);
-        vm.expectRevert();
+        // OutOfFunds is an EVM error with no Solidity revert data.
+        vm.expectRevert(new bytes(0));
         feedConsumer.getFeedValue(ETH_USD_FEED_ID, 3600);
 
-        vm.expectRevert();
+        vm.expectRevert(new bytes(0));
         feedConsumer.getFeedValue{value: alice.balance}(ETH_USD_FEED_ID, 3600);
 
         vm.deal(alice, fee);


### PR DESCRIPTION
## Summary
- Fixes bare `vm.expectRevert()` calls in `testFtsoV2LTSGetFeedPaid` (issue #78)
- Both underpaid `getFeedValue` calls trigger an EVM-level `OutOfFunds` error before FtsoV2 executes, producing empty revert data
- Replaced with `vm.expectRevert(new bytes(0))` to explicitly assert no-data reverts; a future change that introduces a Solidity custom error would now correctly break the test

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)