### PR TITLE
build(prelude): add BuildPointers.sol and forge fmt to regenerate step

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,8 @@
                 -l none \
                 -o meta/FlareFtsoWords.rain.meta \
                 ;
+              forge script --silent ./script/BuildPointers.sol;
+              forge fmt;
             '';
             additionalBuildInputs = rainix.sol-build-inputs.${system} ++ [ rain.defaultPackage.${system} ];
           };

--- a/script/build.sh
+++ b/script/build.sh
@@ -9,4 +9,6 @@ nix develop -c bash -euxo pipefail -c '
   mkdir -p meta
   forge script --silent ./script/BuildAuthoringMeta.sol
   rain meta build -i <(cat ./meta/FlareFtsoSubParserAuthoringMeta.rain.meta) -m authoring-meta-v2 -t cbor -e deflate -l none -o meta/FlareFtsoWords.rain.meta
+  forge script --silent ./script/BuildPointers.sol
+  forge fmt
 '


### PR DESCRIPTION
Adds `forge script --silent ./script/BuildPointers.sol` and `forge fmt` to both `script/build.sh` and the `rain-flare-prelude` nix task in `flake.nix`.

Previously the prelude only regenerated the authoring meta (`BuildAuthoringMeta.sol` + `rain meta build`), so `src/generated/FlareFtsoWords.pointers.sol` was never regenerated as part of the copy-artifacts diff check. A contract change that mutated the bytecode or parse meta could silently ship with a stale pointers file.

With this change, every `copy-artifacts` run regenerates and diffs the pointers file as well, turning BYTECODE_HASH, DESCRIBED_BY_META_HASH, PARSE_META, and the function-pointer constants into structurally enforced drift checks.

Closes #48

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to include an additional generation step and automatic formatting.
  * Build outputs are now refreshed more completely during development and release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->