### PR TITLE
fix(deploy): assert meta file matches compiled DESCRIBED_BY_META_HASH

### DIFF
--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.25;
 
 import {Script} from "forge-std-1.16.1/src/Script.sol";
 import {FlareFtsoWords} from "../src/concrete/FlareFtsoWords.sol";
+import {DESCRIBED_BY_META_HASH} from "../src/generated/FlareFtsoWords.pointers.sol";
 import {IMetaBoardV1_2} from "rain-metadata-0.1.0/src/interface/unstable/IMetaBoardV1_2.sol";
 import {LibDescribedByMeta} from "rain-metadata-0.1.0/src/lib/LibDescribedByMeta.sol";
 
@@ -12,6 +13,11 @@ contract Deploy is Script {
         uint256 deployerPrivateKey = vm.envUint("DEPLOYMENT_KEY");
         bytes memory subParserDescribedByMeta = vm.readFileBinary("meta/FlareFtsoWords.rain.meta");
         IMetaBoardV1_2 metaboard = IMetaBoardV1_2(vm.envAddress("DEPLOY_METABOARD_ADDRESS"));
+
+        require(
+            keccak256(subParserDescribedByMeta) == DESCRIBED_BY_META_HASH,
+            "meta file does not match compiled DESCRIBED_BY_META_HASH"
+        );
 
         vm.startBroadcast(deployerPrivateKey);
         FlareFtsoWords subParser = new FlareFtsoWords();


### PR DESCRIPTION
Adds a `require` in `script/Deploy.sol` before `vm.startBroadcast` that verifies the on-disk meta file's keccak256 matches the `DESCRIBED_BY_META_HASH` compiled into the contract. This prevents deploying a contract with a mismatched meta (e.g. if the authoring meta was regenerated but the pointers file was not, or vice versa).

Without this guard, a dev could run `script/build.sh` (which regenerates the `.rain.meta` file) and deploy with stale pointers — or regenerate only the pointers and deploy with a stale `.rain.meta` — resulting in an on-chain contract permanently associated with the wrong authoring meta.

The check is a pre-broadcast guard: if it fails the script reverts before any on-chain state is written.

Closes #49

Co-Authored-By: Claude <noreply@anthropic.com>