### PR TITLE
test(staleness): pin exact-timeout and just-stale LTS boundary tests

### DIFF
--- a/test/src/lib/lts/LibFtsoV2LTS.t.sol
+++ b/test/src/lib/lts/LibFtsoV2LTS.t.sol
@@ -30,6 +30,48 @@ contract LibFtsoV2LTSTest is Test {
         feedConsumer.getFeedValue(ETH_USD_FEED_ID, 3600);
     }
 
+    /// block.timestamp == feedTimestamp + timeout: the staleness check is strict `>`,
+    /// so this must succeed (not stale).
+    function testFtsoV2LTSGetFeedExactTimeoutNotStale() external {
+        vm.createSelectFork(LibFork.rpcUrlFlare(vm), BLOCK_NUMBER);
+
+        FeedConsumer feedConsumer = new FeedConsumer();
+        vm.warp(1729795768 + 3600);
+        uint256 value = feedConsumer.getFeedValue(ETH_USD_FEED_ID, 3600);
+        assertGt(value, 0);
+    }
+
+    /// block.timestamp == feedTimestamp + timeout + 1: one second past the boundary
+    /// must revert with StalePrice.
+    function testFtsoV2LTSGetFeedJustStale() external {
+        vm.createSelectFork(LibFork.rpcUrlFlare(vm), BLOCK_NUMBER);
+
+        FeedConsumer feedConsumer = new FeedConsumer();
+        vm.warp(1729795768 + 3600 + 1);
+        vm.expectRevert(abi.encodeWithSelector(StalePrice.selector, 1729795768, 3600));
+        feedConsumer.getFeedValue(ETH_USD_FEED_ID, 3600);
+    }
+
+    /// timeout == 0: any block.timestamp strictly after feedTimestamp is stale.
+    function testFtsoV2LTSGetFeedTimeoutZeroStale() external {
+        vm.createSelectFork(LibFork.rpcUrlFlare(vm), BLOCK_NUMBER);
+
+        FeedConsumer feedConsumer = new FeedConsumer();
+        vm.warp(1729795768 + 1);
+        vm.expectRevert(abi.encodeWithSelector(StalePrice.selector, 1729795768, 0));
+        feedConsumer.getFeedValue(ETH_USD_FEED_ID, 0);
+    }
+
+    /// timeout == 0 at exactly feedTimestamp: not stale (0 > 0 is false).
+    function testFtsoV2LTSGetFeedTimeoutZeroExactNotStale() external {
+        vm.createSelectFork(LibFork.rpcUrlFlare(vm), BLOCK_NUMBER);
+
+        FeedConsumer feedConsumer = new FeedConsumer();
+        vm.warp(1729795768);
+        uint256 value = feedConsumer.getFeedValue(ETH_USD_FEED_ID, 0);
+        assertGt(value, 0);
+    }
+
     /// forge-config: default.fuzz.runs = 1
     function testFtsoV2LTSGetFeedPaid(uint128 fee) external {
         vm.assume(fee > 0);


### PR DESCRIPTION
Closes #55

## Problem

`testFtsoV2LTSGetFeedStale` exercised only a single stale point (warp +3601 over a 3600 timeout). The off-by-one boundary of the `block.timestamp > timestamp + timeout` predicate was unverified: a regression flipping `>` to `>=` (or an off-by-one in the timeout arithmetic) would not be caught.

`timeout == 0` (every block is stale once the feed is updated) was also unexercised.

## Fix

Adds four boundary tests to `LibFtsoV2LTSTest`:

| Test | condition | expected |
|------|-----------|---------|
| `testFtsoV2LTSGetFeedExactTimeoutNotStale` | `block.timestamp == feedTimestamp + timeout` | succeeds (strict `>` so equal is not stale) |
| `testFtsoV2LTSGetFeedJustStale` | `block.timestamp == feedTimestamp + timeout + 1` | reverts `StalePrice` |
| `testFtsoV2LTSGetFeedTimeoutZeroStale` | `timeout == 0`, `block.timestamp = feedTimestamp + 1` | reverts `StalePrice` |
| `testFtsoV2LTSGetFeedTimeoutZeroExactNotStale` | `timeout == 0`, `block.timestamp == feedTimestamp` | succeeds |

All four tests use `vm.warp(absolute)` anchored to the hardcoded feed timestamp `1729795768` (the ETH_USD feed value at `BLOCK_NUMBER = 31843105`, already used in the existing stale test). All 7 `LibFtsoV2LTSTest` tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for feed freshness edge cases, including exact timeout boundaries and zero-timeout behavior.
  * Improved validation that stale feed values correctly revert while fresh values remain usable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->