### PR TITLE
test(pointers): assert BYTECODE_HASH matches deployed FlareFtsoWords codehash

### DIFF
--- a/test/src/concrete/FlareFtsoWords.pointers.t.sol
+++ b/test/src/concrete/FlareFtsoWords.pointers.t.sol
@@ -14,6 +14,7 @@ import {
 } from "src/concrete/FlareFtsoWords.sol";
 import {LibGenParseMeta} from "rain-interpreter-interface-0.1.0/src/lib/codegen/LibGenParseMeta.sol";
 import {LibFlareFtsoSubParser} from "src/lib/parse/LibFlareFtsoSubParser.sol";
+import {BYTECODE_HASH} from "src/generated/FlareFtsoWords.pointers.sol";
 
 contract FlareFtsoWordsPointersTest is Test {
     function testIntegrityPointers() external {
@@ -41,5 +42,10 @@ contract FlareFtsoWordsPointersTest is Test {
         AuthoringMetaV2[] memory authoringMeta = abi.decode(authoringMetaBytes, (AuthoringMetaV2[]));
         bytes memory expected = LibGenParseMeta.buildParseMetaV2(authoringMeta, 2);
         assertEq(SUB_PARSER_PARSE_META, expected);
+    }
+
+    function testBytecodeHashMatchesDeployedCode() external {
+        FlareFtsoWords flareFtsoWords = new FlareFtsoWords();
+        assertEq(address(flareFtsoWords).codehash, BYTECODE_HASH, "BYTECODE_HASH is stale");
     }
 }


### PR DESCRIPTION
Closes #63

## Problem

`BYTECODE_HASH` in `src/generated/FlareFtsoWords.pointers.sol` was an autogenerated constant with zero consumers and no structural test. A source change followed by a forgotten `BuildPointers.sol` regeneration would produce a stale hash that can't be caught at test time.

## Fix

Adds `testBytecodeHashMatchesDeployedCode` to `FlareFtsoWordsPointersTest`. The test deploys `FlareFtsoWords` and asserts that `address(flareFtsoWords).codehash == BYTECODE_HASH`. A stale hash now fails `forge test` immediately.

All 6 pointer tests pass.