### PR TITLE
docs(sflr): add @return and clarify sFLR-per-FLR rate direction in run() NatSpec

### DIFF
--- a/src/lib/op/LibOpSFlrCurrentExchangeRate.sol
+++ b/src/lib/op/LibOpSFlrCurrentExchangeRate.sol
@@ -9,13 +9,18 @@ import {LibDecimalFloat, Float} from "rain-math-float-0.1.1/src/lib/LibDecimalFl
 /// @title LibOpSFLRCurrentExchangeRate
 /// Implements the `sflrCurrentExchangeRate` externed opcode.
 library LibOpSFLRCurrentExchangeRate {
-    /// Extern integrity for getting the current exchange rate of FLR to SFLR.
+    /// Extern integrity for getting the current sFLR-per-FLR exchange rate.
+    /// Takes 0 inputs and produces 1 output.
     function integrity(OperandV2, uint256, uint256) internal pure returns (uint256, uint256) {
         return (0, 1);
     }
 
-    /// Extern implementation for reading the current exchange rate of FLR to sFLR
-    /// based on directly reading the underlying assets self-reported by the sFLR contract.
+    /// Extern implementation for reading the current sFLR-per-FLR exchange rate
+    /// as self-reported by the sFLR contract.  The rate is the number of sFLR
+    /// tokens received for each FLR deposited (typically less than 1.0 because
+    /// sFLR accrues value relative to FLR over time).
+    /// @return outputs The outputs of the operation.
+    ///   0. The sFLR-per-FLR exchange rate as an 18-decimal Float.
     function run(OperandV2, StackItem[] memory) internal view returns (StackItem[] memory) {
         uint256 rate18 = LibSceptreStakedFlare.getSFLRPerFLR18();
         Float rateFloat = LibDecimalFloat.fromFixedDecimalLosslessPacked(rate18, 18);


### PR DESCRIPTION
Closes #94

## Summary

`LibOpSFlrCurrentExchangeRate.run()` had no `@return` NatSpec and the existing description "FLR to sFLR" was ambiguous about direction.

Changes:
- Adds `@return` documenting that the output is the sFLR-per-FLR exchange rate as an 18-decimal Float.
- Rewrites the `run()` doc comment to state the direction unambiguously: the number of sFLR received per FLR deposited (typically < 1.0 because sFLR accrues value relative to FLR over time).
- Fixes `integrity()` comment: "SFLR" → "sFLR" for consistency and clarifies 0-inputs/1-output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)