### PR TITLE
Remove @custom:error block duplicating @dev revert docs

### DIFF
--- a/src/lib/op/LibOpFtsoCurrentPriceUsd.sol
+++ b/src/lib/op/LibOpFtsoCurrentPriceUsd.sol
@@ -36,10 +36,6 @@ library LibOpFtsoCurrentPriceUsd {
     ///      updating for some time.
     /// @return outputs The outputs of the operation. Always 1 item.
     ///   0. The price of the asset in USD, as a Float.
-    /// @custom:error DecimalsTooLarge Reverts if the FTSO reports more than
-    ///   `type(uint8).max` decimals. Also propagates `InactiveFtso`,
-    ///   `PriceNotFinalized`, `StalePrice`, and `InconsistentFtso` from
-    ///   `LibFtsoCurrentPriceUsd.ftsoCurrentPriceUsd`.
     function run(OperandV2, StackItem[] memory inputs) internal view returns (StackItem[] memory) {
         IntOrAString symbol;
         Float timeout;


### PR DESCRIPTION
Deletes the `@custom:error` block on `LibOpFtsoCurrentPriceUsd.run()` — every fact in it (InactiveFtso/PriceNotFinalized/InconsistentFtso/StalePrice propagation, DecimalsTooLarge above 255 = `type(uint8).max` decimals) is already in the `@dev` prose directly above. This is the last `@custom:` tag in the repo, so it un-reds `rainix-sol / static` (the org no-custom-natspec gate from rainlanguage/rainix#254) for every open rain.flare PR.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)