### PR TITLE
test: assert authoringMetaV2 descriptions state correct operand input counts

### DIFF
--- a/test/src/concrete/FlareFtsoWords.pointers.t.sol
+++ b/test/src/concrete/FlareFtsoWords.pointers.t.sol
@@ -66,6 +66,51 @@ contract FlareFtsoWordsPointersTest is Test {
         assertTrue(bytes(m[SUB_PARSER_WORD_FTSO_CURRENT_PRICE_USD].description).length > 0);
         assertTrue(bytes(m[SUB_PARSER_WORD_FTSO_CURRENT_PRICE_PAIR].description).length > 0);
         assertTrue(bytes(m[SUB_PARSER_WORD_SFLR_EXCHANGE_RATE].description).length > 0);
+        // Each description states the word's operand input count, which must
+        // match the fixed arity enforced by that word's `integrity` function.
+        // ftso-current-price-usd: integrity (2,1) => "2 input".
+        assertTrue(
+            contains(m[SUB_PARSER_WORD_FTSO_CURRENT_PRICE_USD].description, "2 input"),
+            "usd description input count does not match integrity arity (2,1)"
+        );
+        // ftso-current-price-pair: integrity (3,1) => "3 input".
+        assertTrue(
+            contains(m[SUB_PARSER_WORD_FTSO_CURRENT_PRICE_PAIR].description, "3 input"),
+            "pair description input count does not match integrity arity (3,1)"
+        );
+        // sflr-exchange-rate: integrity (0,1) => "0 input".
+        assertTrue(
+            contains(m[SUB_PARSER_WORD_SFLR_EXCHANGE_RATE].description, "0 input"),
+            "sflr description input count does not match integrity arity (0,1)"
+        );
+    }
+
+    /// @dev Minimal substring check as Solidity has no built-in for strings.
+    /// Returns true iff `needle` occurs somewhere within `haystack`. The
+    /// `needle.length > haystack.length` guard keeps the window comparison in
+    /// bounds (and returns false, as a longer needle cannot be contained).
+    function contains(string memory haystack, string memory needle) internal pure returns (bool) {
+        bytes memory h = bytes(haystack);
+        bytes memory n = bytes(needle);
+        if (n.length == 0) {
+            return true;
+        }
+        if (n.length > h.length) {
+            return false;
+        }
+        for (uint256 i = 0; i <= h.length - n.length; i++) {
+            bool matched = true;
+            for (uint256 j = 0; j < n.length; j++) {
+                if (h[i + j] != n[j]) {
+                    matched = false;
+                    break;
+                }
+            }
+            if (matched) {
+                return true;
+            }
+        }
+        return false;
     }
 
     function testBytecodeHashMatchesDeployedCode() external {


### PR DESCRIPTION
## What

Extends the existing `testAuthoringMetaContent` in `test/src/concrete/FlareFtsoWords.pointers.t.sol` so that each `FlareFtsoWords` sub-parser word's `authoringMetaV2` description is asserted to state the correct operand **input count**, and pins that count to the fixed arity enforced by the word's `integrity` function.

Previously nothing checked that the human-readable "Accepts N inputs" text agreed with the actual arity — a description could drift from the integrity contract silently.

## Arities pinned

| word | index | integrity | asserted substring | description text |
|---|---|---|---|---|
| `ftso-current-price-usd` | 0 | `(2, 1)` | `"2 input"` | "...Accepts 2 inputs..." |
| `ftso-current-price-pair` | 1 | `(3, 1)` | `"3 input"` | "...Accepts 3 inputs..." |
| `sflr-exchange-rate` | 2 | `(0, 1)` | `"0 input"` | "...Accepts 0 inputs." |

Arities confirmed in `src/lib/op/LibOpFtsoCurrentPriceUsd.sol` `(2,1)`, `LibOpFtsoCurrentPricePair.sol` `(3,1)`, `LibOpSFlrCurrentExchangeRate.sol` `(0,1)`.

Adds a small, bounds-guarded `contains(string haystack, string needle)` pure helper (Solidity has no built-in string substring check; the repo had no existing `LibString.contains`/helper). The `needle.length > haystack.length` guard keeps the byte-window comparison in bounds.

## Discrimination proof

Each assertion passes on current source and fails if that word's stated count is wrong. Verified by temporarily mutating each description's count in the source (then restoring — no mutation committed), running `--match-test testAuthoringMetaContent`:

- `Accepts 2 inputs` -> `5 inputs` => `[FAIL: usd description input count does not match integrity arity (2,1)]`
- `Accepts 3 inputs` -> `5 inputs` => `[FAIL: pair description input count does not match integrity arity (3,1)]`
- `Accepts 0 inputs` -> `9 inputs` => `[FAIL: sflr description input count does not match integrity arity (0,1)]`

Unmutated: all 8 tests in the suite pass (`testAuthoringMetaContent` green).

## Scope

Test-only, additive. No source/bytecode change, so no pointer/meta regeneration.

## Closes

Closes #84.

The existing `testAuthoringMetaContent` already asserts `authoringMetaV2()` decodes to the right length and pins each word **name** to its **index** (USD=0, PAIR=1, sFLR=2) plus non-empty descriptions — the index->name mapping the F33 audit finding asked for. This PR adds the remaining piece of the finding's proposed fix: asserting the **description content** (the input-count phrasing). Together they fully implement the fix proposed in #84, so this closes it.

This is also the completion of the closed PR #187's partial idea — #187 covered only USD + PAIR (omitting sFLR) and duplicated the already-merged name/index coverage; this covers all three words and adds only the missing content assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation of authoring metadata to confirm operand-input counts are accurately reflected in word descriptions.
  * Added coverage for words requiring two, three, and zero inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->