### PR TITLE
fix: rename the codegen script to script/Build.sol

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ CI usage.
 Run `./script/build.sh` to regenerate every committed artifact that the
 `rainix-sol-artifacts` CI check diffs against: `meta/*.rain.meta` (the CBOR
 encoded authoring-meta blob) and — after `build.sh` completes — run the
-`BuildPointers.sol` forge script to update `src/generated/*.pointers.sol`
+`Build.sol` forge script to update `src/generated/*.pointers.sol`
 (contains `DESCRIBED_BY_META_HASH` and `BYTECODE_HASH`):
 
 ```
 ./script/build.sh
-nix develop .#sol-shell -c forge script ./script/BuildPointers.sol
+nix develop .#sol-shell -c forge script ./script/Build.sol
 ```
 
 Commit the resulting changes whenever word descriptions, operand meta, or the

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ is 0.06 in 18 decimal fixed point math.
 All the same considerations and behaviours of individual USD prices fetches are
 applied to the two internal fetches for this word.
 
-Note that as the price is derived from independent data points, there is no
-real FTSO reporting it, and no guarantee the prices are even from the same block.
-In theory, a large timeout, coupled with high volatility and large discrepencies
-between the two internal FTSO "current price" timestamps could lead to inaccurate
-pricings. Using a short timeout should generally mitigate this risk, as FTSO data
-points aren't backed by directly tradeable liquidity anyway, and are themselves
-derived as a median of several reported values.
+Note that as the price is derived from independent data points, there is no real
+FTSO reporting it, and no guarantee the prices are even from the same block. In
+theory, a large timeout, coupled with high volatility and large discrepencies
+between the two internal FTSO "current price" timestamps could lead to
+inaccurate pricings. Using a short timeout should generally mitigate this risk,
+as FTSO data points aren't backed by directly tradeable liquidity anyway, and
+are themselves derived as a median of several reported values.
 
 Regardless, it is NOT recommended that this word be used for high precision
 calculations, as derived prices can drift from reality simply due to differences
@@ -60,8 +60,8 @@ section below, which also rounds down.
 
 ### Timeouts
 
-The rainlang author must provide a timeout which is used to guarantee that prices
-are never older than this many seconds relative to now.
+The rainlang author must provide a timeout which is used to guarantee that
+prices are never older than this many seconds relative to now.
 
 If the author does not care about the age of some price they can simply set this
 to the max int value.
@@ -105,8 +105,8 @@ CI usage.
 Run `./script/build.sh` to regenerate every committed artifact that the
 `rainix-sol-artifacts` CI check diffs against: `meta/*.rain.meta` (the CBOR
 encoded authoring-meta blob) and — after `build.sh` completes — run the
-`Build.sol` forge script to update `src/generated/*.pointers.sol`
-(contains `DESCRIBED_BY_META_HASH` and `BYTECODE_HASH`):
+`Build.sol` forge script to update `src/generated/*.pointers.sol` (contains
+`DESCRIBED_BY_META_HASH` and `BYTECODE_HASH`):
 
 ```
 ./script/build.sh
@@ -114,12 +114,13 @@ nix develop .#sol-shell -c forge script ./script/Build.sol
 ```
 
 Commit the resulting changes whenever word descriptions, operand meta, or the
-deployed contract changes.  The CI `copy-artifacts` job diffs these files and
+deployed contract changes. The CI `copy-artifacts` job diffs these files and
 turns red on drift.
 
 ## Legal stuff
 
-Everything is under DecentraLicense 1.0 (DCL-1.0) which can be found in `LICENSES/`.
+Everything is under DecentraLicense 1.0 (DCL-1.0) which can be found in
+`LICENSES/`.
 
 This is basically `CAL-1.0` which is an open source license
 https://opensource.org/license/cal-1-0
@@ -131,8 +132,8 @@ to those users as relevant, and that private keys remain private.
 Roughly it's "not your keys, not your coins" aware, as close as we could get in
 legalese.
 
-This is the default situation on permissionless blockchains, so shouldn't require
-any additional effort by dev-users to adhere to the license terms.
+This is the default situation on permissionless blockchains, so shouldn't
+require any additional effort by dev-users to adhere to the license terms.
 
 This repo is REUSE 3.2 compliant https://reuse.software/spec-3.2/ and compatible
 with `reuse` tooling (also available in the nix shell here).

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
                 -l none \
                 -o meta/FlareFtsoWords.rain.meta \
                 ;
-              forge script --silent ./script/BuildPointers.sol;
+              forge script --silent ./script/Build.sol;
               forge fmt;
             '';
             additionalBuildInputs = rainix.sol-build-inputs.${system} ++ [ rain.defaultPackage.${system} ];

--- a/script/Build.sol
+++ b/script/Build.sol
@@ -11,7 +11,7 @@ import {PARSE_META_BUILD_DEPTH} from "src/generated/FlareFtsoWords.pointers.sol"
 import {LibFlareFtsoSubParser} from "src/lib/parse/LibFlareFtsoSubParser.sol";
 import {LibGenParseMeta} from "rain-interpreter-interface-0.1.0/src/lib/codegen/LibGenParseMeta.sol";
 
-contract BuildPointers is Script {
+contract Build is Script {
     function buildFlareFtsoWordsPointers() internal {
         FlareFtsoWords flareFtsoWords = new FlareFtsoWords();
 


### PR DESCRIPTION
rainlanguage/rainix#272 (merged, `ef89e90`) made `rainix-copy-artifacts` require the codegen script to be `script/Build.sol`, matched exactly. This repo's script is `script/BuildPointers.sol`, so its `copy-artifacts` job now **errors** until renamed.

That guard replaced an `if: hashFiles('script/BuildPointers.sol')` gate whose failure mode was worse than a red: a repo whose script didn't match that exact name had regeneration **silently skipped**, and the "committed artifacts match freshly built" assert then passed having regenerated nothing — a green over an unchecked tree.

## Change

- `script/BuildPointers.sol` -> `script/Build.sol`, `contract BuildPointers` -> `contract Build`.
- References to the script updated (docs, comments, and any invocation).

The generated `src/generated/*.pointers.sol` files are deliberately **untouched**. Their `AUTOGENERATED BY ./script/BuildPointers.sol` header is emitted by this repo's pinned `rain-sol-codegen`, which still writes that name, so regeneration reproduces them byte-for-byte and `copy-artifacts` stays green. The header and the `.pointers.sol` suffix change when this repo bumps to codegen 0.1.4+ (rainlanguage/rain.sol.codegen#31), which is separate work.

The name: the generated file is a set of constants for a contract, and only the interpreter/word repos generate an actual function pointer table — so "pointers" named the exception rather than the thing.
