### PR TITLE
Drop foundry.toml release metadata: version intent lives in next-v tags (rainix#335)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,3 @@
-[package]
-name = "rain-flare"
-version = "0.1.2"
-
 [profile.default]
 libs = ['dependencies']
 


### PR DESCRIPTION
Deletes the legacy `[package]` release-metadata section (name/version) from `foundry.toml`, per the ruling in rainlanguage/rainix#335. Since rainlanguage/rainix#336 merged, `rainix-autopublish` derives the publish version from the Soldeer registry plus `next-v*` git tags and never reads this section; the publish gate also excludes the section from the content hash, so this deletion is content-neutral and cannot mint a release.

## QA
- Discriminating tests: n/a - config-metadata deletion; nothing reads the section since rainix#336. Verified locally: `nix develop -c reuse lint`, `nix develop -c forge soldeer install`, and `nix develop -c forge build` green. Suite left to CI: the tests are fork tests against a Flare RPC - pushed first rather than running the fork suite locally.
- Mutations applied: n/a - no code changed
- Oracle: rainix#336 gate semantics (section excluded from content hash; version from registry + next-v tags)
- Category check: issue asks removal of release metadata from consumers; covered exactly for this repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed package metadata from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->